### PR TITLE
add dedicated catch clause for InterruptedIOException to prevent race…

### DIFF
--- a/fahrschein/src/main/java/org/zalando/fahrschein/NakadiReader.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/NakadiReader.java
@@ -35,7 +35,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
@@ -302,6 +301,9 @@ class NakadiReader<T> implements IORunnable {
                 readBatch(jsonParser);
 
                 errorCount = 0;
+            } catch (InterruptedIOException e) {
+                LOG.info("Got [{}] [{}] while reading events for {}", e.getClass().getSimpleName(), e.getMessage(), eventNames, e);
+                break;
             } catch (IOException e) {
 
                 metricsCollector.markErrorWhileConsuming();

--- a/fahrschein/src/main/java/org/zalando/fahrschein/NakadiReader.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/NakadiReader.java
@@ -295,13 +295,13 @@ class NakadiReader<T> implements IORunnable {
                 final JsonParser jsonParser = jsonInput.getJsonParser();
 
                 if (Thread.currentThread().isInterrupted()) {
-                    throw new InterruptedIOException("Interrupted");
+                    throw new ThreadInterruptedException();
                 }
 
                 readBatch(jsonParser);
 
                 errorCount = 0;
-            } catch (InterruptedIOException e) {
+            } catch (ThreadInterruptedException e) {
                 LOG.info("Got [{}] [{}] while reading events for {}", e.getClass().getSimpleName(), e.getMessage(), eventNames, e);
                 break;
             } catch (IOException e) {

--- a/fahrschein/src/main/java/org/zalando/fahrschein/ThreadInterruptedException.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/ThreadInterruptedException.java
@@ -1,0 +1,4 @@
+package org.zalando.fahrschein;
+
+public class ThreadInterruptedException extends Exception{
+}


### PR DESCRIPTION
… conditions.

As a live situation revealed a race condition between both ``Thread.currentThread().isInterrupted()`` this PR let the main loop explicitly stop when in the try part the thread was interrupted