### PR TITLE
Add support for Open Tracing's span context.

### DIFF
--- a/fahrschein/src/main/java/org/zalando/fahrschein/domain/Metadata.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/domain/Metadata.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.annotation.concurrent.Immutable;
 import java.time.OffsetDateTime;
+import java.util.HashMap;
+import java.util.Map;
 
 @Immutable
 public final class Metadata {
@@ -13,23 +15,25 @@ public final class Metadata {
     private final OffsetDateTime occurredAt;
     private final OffsetDateTime receivedAt;
     private final String flowId;
+    private final Map<String, String> spanCtx;
 
     @JsonCreator
     @Deprecated
-    private Metadata(@JsonProperty("event_type") String eventType, @JsonProperty("eid") String eid, @JsonProperty("occurred_at") String occurredAt, @JsonProperty("received_at") String receivedAt, @JsonProperty("flow_id") String flowId) {
-        this(eventType, eid, occurredAt == null ? null : OffsetDateTime.parse(occurredAt), receivedAt == null ? null : OffsetDateTime.parse(receivedAt), flowId);
+    private Metadata(@JsonProperty("event_type") String eventType, @JsonProperty("eid") String eid, @JsonProperty("occurred_at") String occurredAt, @JsonProperty("received_at") String receivedAt, @JsonProperty("flow_id") String flowId, @JsonProperty("span_ctx") Map<String, String> spanCtx) {
+        this(eventType, eid, occurredAt == null ? null : OffsetDateTime.parse(occurredAt), receivedAt == null ? null : OffsetDateTime.parse(receivedAt), flowId, spanCtx);
     }
 
-    public Metadata(String eventType, String eid, OffsetDateTime occurredAt, OffsetDateTime receivedAt, String flowId) {
+    public Metadata(String eventType, String eid, OffsetDateTime occurredAt, OffsetDateTime receivedAt, String flowId, Map<String, String> spanCtx) {
         this.eventType = eventType;
         this.eid = eid;
         this.occurredAt = occurredAt;
         this.receivedAt = receivedAt;
         this.flowId = flowId;
+        this.spanCtx = spanCtx;
     }
 
     public Metadata(String eid, OffsetDateTime occurredAt) {
-        this(null, eid, occurredAt, null, null);
+        this(null, eid, occurredAt, null, null, null);
     }
 
     public String getEventType() {
@@ -50,5 +54,9 @@ public final class Metadata {
 
     public String getFlowId() {
         return flowId;
+    }
+
+    public Map<String, String> getSpanCtx() {
+        return spanCtx;
     }
 }

--- a/fahrschein/src/main/java/org/zalando/fahrschein/domain/Metadata.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/domain/Metadata.java
@@ -1,10 +1,13 @@
 package org.zalando.fahrschein.domain;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.annotation.concurrent.Immutable;
 import java.time.OffsetDateTime;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -15,25 +18,24 @@ public final class Metadata {
     private final OffsetDateTime occurredAt;
     private final OffsetDateTime receivedAt;
     private final String flowId;
-    private final Map<String, String> spanCtx;
+    private final Map<String, Object> other = new HashMap<String, Object>();
 
     @JsonCreator
     @Deprecated
-    private Metadata(@JsonProperty("event_type") String eventType, @JsonProperty("eid") String eid, @JsonProperty("occurred_at") String occurredAt, @JsonProperty("received_at") String receivedAt, @JsonProperty("flow_id") String flowId, @JsonProperty("span_ctx") Map<String, String> spanCtx) {
-        this(eventType, eid, occurredAt == null ? null : OffsetDateTime.parse(occurredAt), receivedAt == null ? null : OffsetDateTime.parse(receivedAt), flowId, spanCtx);
+    private Metadata(@JsonProperty("event_type") String eventType, @JsonProperty("eid") String eid, @JsonProperty("occurred_at") String occurredAt, @JsonProperty("received_at") String receivedAt, @JsonProperty("flow_id") String flowId) {
+        this(eventType, eid, occurredAt == null ? null : OffsetDateTime.parse(occurredAt), receivedAt == null ? null : OffsetDateTime.parse(receivedAt), flowId);
     }
 
-    public Metadata(String eventType, String eid, OffsetDateTime occurredAt, OffsetDateTime receivedAt, String flowId, Map<String, String> spanCtx) {
+    public Metadata(String eventType, String eid, OffsetDateTime occurredAt, OffsetDateTime receivedAt, String flowId) {
         this.eventType = eventType;
         this.eid = eid;
         this.occurredAt = occurredAt;
         this.receivedAt = receivedAt;
         this.flowId = flowId;
-        this.spanCtx = spanCtx;
     }
 
     public Metadata(String eid, OffsetDateTime occurredAt) {
-        this(null, eid, occurredAt, null, null, null);
+        this(null, eid, occurredAt, null, null);
     }
 
     public String getEventType() {
@@ -56,7 +58,17 @@ public final class Metadata {
         return flowId;
     }
 
-    public Map<String, String> getSpanCtx() {
-        return spanCtx;
+    @JsonAnySetter
+    public void set(String name, Object value) {
+        other.put(name, value);
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> any() {
+        return Collections.unmodifiableMap(other);
+    }
+
+    public Object get(String name) {
+        return other.get(name);
     }
 }

--- a/fahrschein/src/test/java/org/zalando/fahrschein/NakadiReaderDeserializationTest.java
+++ b/fahrschein/src/test/java/org/zalando/fahrschein/NakadiReaderDeserializationTest.java
@@ -184,11 +184,11 @@ public class NakadiReaderDeserializationTest {
         assertThat(metadata.getFlowId(), Matchers.equalTo("ABCD"));
         assertThat(metadata.getOccurredAt(), Matchers.equalTo(OffsetDateTime.of(2016, 10, 26, 19, 20, 21, 123_000_000, ZoneOffset.UTC)));
         assertThat(metadata.getReceivedAt(), Matchers.equalTo(OffsetDateTime.of(2016, 10, 26, 20, 21, 22, 0, ZoneOffset.ofHours(1))));
-        assertThat(metadata.getSpanCtx(), Matchers.equalTo(null));
+        assertThat(metadata.any(), Matchers.equalTo(new HashMap<String, Object>()));
     }
 
     @Test
-    public void shouldDeserializeSpanCtxInBusinessEventMetadata() throws IOException {
+    public void shouldDeserializeSpanContextInBusinessEventMetadata() throws IOException {
         setupResponse(1, 1, "{\"metadata\":{\"eid\":\"5678\",\"occurred_at\":\"2016-10-26T19:20:21.123Z\",\"received_at\":\"2016-10-26T20:21:22+01:00\",\"flow_id\":\"ABCD\",\"span_ctx\":{\"ot-tracer-spanid\":\"78cc5b6e96e8a5a2\",\"ot-tracer-traceid\":\"9df69e766320993f\",\"ot-tracer-sampled\":\"true\"}},\"sales_order\":{\"order_number\":\"1234\"}}");
 
         final List<SalesOrderPlaced> events = readSingleBatch("sales-salesOrder-placed", SalesOrderPlaced.class);
@@ -199,9 +199,10 @@ public class NakadiReaderDeserializationTest {
         final SalesOrder salesOrder = salesOrderPlaced.getSalesOrder();
         final Metadata metadata = salesOrderPlaced.getMetadata();
 
-        assertThat(metadata.getSpanCtx(), Matchers.hasEntry("ot-tracer-spanid", "78cc5b6e96e8a5a2"));
-        assertThat(metadata.getSpanCtx(), Matchers.hasEntry("ot-tracer-traceid", "9df69e766320993f"));
-        assertThat(metadata.getSpanCtx(), Matchers.hasEntry("ot-tracer-sampled", "true"));
+        final Map<String, String> spanContext = (Map<String, String>) metadata.get("span_ctx");
+        assertThat(spanContext, Matchers.hasEntry("ot-tracer-spanid", "78cc5b6e96e8a5a2"));
+        assertThat(spanContext, Matchers.hasEntry("ot-tracer-traceid", "9df69e766320993f"));
+        assertThat(spanContext, Matchers.hasEntry("ot-tracer-sampled", "true"));
     }
 
     @Test


### PR DESCRIPTION
# Overview
After addition of propagation support of Open Tracing's span context to Nakadi through `span_ctx` attribute in `metadata` we need to be able to reach span context in received events by using client libraries.

Changes in this pull request give ability to retrieve span context data as `Map<String, String>` through event's `getMetadata().getSpanCtx()`.

# Changes
- Introduce new `Metadata` attribute `spanCtx`
- Modify `Metadata` constructors to initialize the attribute
- Add getter for the attribute
- Modify test `NakadiReaderDeserializationTest#shouldDeserializeBusinessEventMetadata` to check for empty span context (`null`) when it absent in JSON payload.
- Add test `NakadiReaderDeserializationTest#shouldDeserializeSpanCtxInBusinessEventMetadata` to check proper deserialization of JSON's span context attributes into `spanCtx` map.

# Related Pull Requests
- https://github.com/zalando/nakadi/pull/931