### PR TITLE
Add SimpleZonedDateTimeModule for compatibility with old Jackson Databind

### DIFF
--- a/fahrschein/src/main/java/org/zalando/fahrschein/DefaultObjectMapper.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/DefaultObjectMapper.java
@@ -7,15 +7,26 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.databind.cfg.PackageVersion;
+import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+import org.zalando.fahrschein.datatype.SimpleZonedDateTimeModule;
 
 class DefaultObjectMapper {
     static final ObjectMapper INSTANCE;
+    private static final Version databindVersionCompatibleToJavaTimeModule = new Version(2, 6, 0, null,"com.fasterxml.jackson.core","jackson-databind");
+    private static final Version databindVersionRuntime = PackageVersion.VERSION;
+
     static {
         final ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.setPropertyNamingStrategy(snake_case());
         objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-        objectMapper.registerModules(new Jdk8Module(), new ParameterNamesModule(), new JavaTimeModule());
+        objectMapper.registerModules(new ParameterNamesModule());
+        if(databindVersionRuntime.compareTo(databindVersionCompatibleToJavaTimeModule) >= 0) {
+            objectMapper.registerModules(new Jdk8Module(), new JavaTimeModule());
+        } else {
+            objectMapper.registerModules(new SimpleZonedDateTimeModule());
+        }
         objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
         objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
         INSTANCE = objectMapper;

--- a/fahrschein/src/main/java/org/zalando/fahrschein/datatype/SimpleZonedDateTimeDeserializer.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/datatype/SimpleZonedDateTimeDeserializer.java
@@ -1,0 +1,27 @@
+package org.zalando.fahrschein.datatype;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.io.IOException;
+import java.time.ZonedDateTime;
+
+class SimpleZonedDateTimeDeserializer extends JsonDeserializer<ZonedDateTime> {
+
+    @Override
+    public ZonedDateTime deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
+            throws IOException {
+        ObjectCodec oc = jsonParser.getCodec();
+        JsonNode node = oc.readTree(jsonParser);
+
+        return ZonedDateTime.parse(node.asText());
+    }
+
+    @Override
+    public Class<ZonedDateTime> handledType() {
+        return ZonedDateTime.class;
+    }
+}

--- a/fahrschein/src/main/java/org/zalando/fahrschein/datatype/SimpleZonedDateTimeModule.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/datatype/SimpleZonedDateTimeModule.java
@@ -1,0 +1,16 @@
+package org.zalando.fahrschein.datatype;
+
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+import java.time.ZonedDateTime;
+
+public class SimpleZonedDateTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
+
+    public SimpleZonedDateTimeModule() {
+        super("SimpleZonedDateTimeModule", new Version(1, 0, 0, null, null, null));
+        this.addDeserializer(ZonedDateTime.class, new SimpleZonedDateTimeDeserializer());
+        this.addSerializer(new SimpleZonedDateTimeSerializer());
+    }
+}

--- a/fahrschein/src/main/java/org/zalando/fahrschein/datatype/SimpleZonedDateTimeSerializer.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/datatype/SimpleZonedDateTimeSerializer.java
@@ -1,0 +1,21 @@
+package org.zalando.fahrschein.datatype;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+import java.time.ZonedDateTime;
+
+public class SimpleZonedDateTimeSerializer extends JsonSerializer<ZonedDateTime> {
+    @Override
+    public void serialize(ZonedDateTime zonedDateTime, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
+            throws IOException {
+        jsonGenerator.writeString(zonedDateTime.toInstant().toString());
+    }
+
+    @Override
+    public Class<ZonedDateTime> handledType() {
+        return ZonedDateTime.class;
+    }
+}


### PR DESCRIPTION
Usage of `JavaTimeModule` and `Jdk8Module`, linked to outdated `jackson-databind:2.4.2` results in runtime error
```
Caused by: java.lang.IllegalAccessError: 
tried to access method com.fasterxml.jackson.databind.ser.std.StdSerializer.<init>(Ljava/lang/Class;)V 
from class com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
```
So, linked to old versions of `jackson-databind`, other serializer/deserializer of DateTime should be used.