### PR TITLE
#234 - support authorization for subscriptions

### DIFF
--- a/fahrschein/src/main/java/org/zalando/fahrschein/AuthorizationBuilder.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/AuthorizationBuilder.java
@@ -3,11 +3,12 @@ package org.zalando.fahrschein;
 import org.zalando.fahrschein.domain.Authorization;
 import org.zalando.fahrschein.domain.Authorization.AuthorizationAttribute;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
-import static java.util.stream.Collectors.toList;
 import static org.zalando.fahrschein.domain.Authorization.AuthorizationAttribute.ANYONE;
 
 /**
@@ -29,7 +30,7 @@ public class AuthorizationBuilder {
      * No restrictions by default, use {@link #withAdmins} / {@link #withReaders} methods to add them.
      */
     public static AuthorizationBuilder authorization() {
-        return new AuthorizationBuilder(singletonList(ANYONE), singletonList(ANYONE));
+        return new AuthorizationBuilder(emptyList(), emptyList());
     }
 
     public AuthorizationBuilder withAdmins(List<AuthorizationAttribute> admins) {
@@ -49,18 +50,22 @@ public class AuthorizationBuilder {
     }
 
     public AuthorizationBuilder addAdmin(String dataType, String value) {
-        List<AuthorizationAttribute> newAdmins = admins.stream().filter(aa -> !aa.equals(ANYONE)).collect(toList());
+        List<AuthorizationAttribute> newAdmins = new ArrayList<>(admins.size() + 1);
+        newAdmins.addAll(admins);
         newAdmins.add(new AuthorizationAttribute(dataType, value));
         return withAdmins(newAdmins);
     }
 
     public AuthorizationBuilder addReader(String dataType, String value) {
-        List<AuthorizationAttribute> newReaders = readers.stream().filter(aa -> !aa.equals(ANYONE)).collect(toList());;
+        List<AuthorizationAttribute> newReaders = new ArrayList<>(readers.size() + 1);
+        newReaders.addAll(readers);
         newReaders.add(new AuthorizationAttribute(dataType, value));
         return withReaders(newReaders);
     }
 
     public Authorization build() {
+        List<AuthorizationAttribute> admins = this.admins.isEmpty() ? singletonList(ANYONE) : this.admins;
+        List<AuthorizationAttribute> readers = this.readers.isEmpty() ? singletonList(ANYONE) : this.readers;
         return new Authorization(admins, readers);
     }
 }

--- a/fahrschein/src/main/java/org/zalando/fahrschein/AuthorizationBuilder.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/AuthorizationBuilder.java
@@ -1,0 +1,66 @@
+package org.zalando.fahrschein;
+
+import org.zalando.fahrschein.domain.Authorization;
+import org.zalando.fahrschein.domain.Authorization.AuthorizationAttribute;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Arrays.asList;
+
+public class AuthorizationBuilder {
+
+    private final List<AuthorizationAttribute> admins;
+    private final List<AuthorizationAttribute> readers;
+
+    private AuthorizationBuilder() {
+        admins = null;
+        readers = null;
+    }
+
+    private AuthorizationBuilder(List<AuthorizationAttribute> admins, List<AuthorizationAttribute> readers) {
+        this.admins = admins;
+        this.readers = readers;
+    }
+
+    public static AuthorizationBuilder authorization() {
+        return new AuthorizationBuilder();
+    }
+
+    public static Authorization notRestricted() {
+        return authorization().withAdmins(AuthorizationAttribute.ANYONE).withReaders(AuthorizationAttribute.ANYONE).build();
+    }
+
+    public AuthorizationBuilder withAdmins(List<AuthorizationAttribute> admins) {
+        return new AuthorizationBuilder(admins, readers);
+    }
+
+    public AuthorizationBuilder withReaders(List<AuthorizationAttribute> readers) {
+        return new AuthorizationBuilder(admins, readers);
+    }
+
+    public AuthorizationBuilder withAdmins(AuthorizationAttribute... admins) {
+        return new AuthorizationBuilder(asList(admins), readers);
+    }
+
+    public AuthorizationBuilder withReaders(AuthorizationAttribute... readers) {
+        return new AuthorizationBuilder(admins, asList(readers));
+    }
+
+    public AuthorizationBuilder addAdmin(String dataType, String value) {
+        ArrayList<AuthorizationAttribute> newAdmins = Optional.ofNullable(admins).map(ArrayList::new).orElse(new ArrayList<>());
+        newAdmins.add(new AuthorizationAttribute(dataType, value));
+        return withAdmins(newAdmins);
+    }
+
+    public AuthorizationBuilder addReader(String dataType, String value) {
+        ArrayList<AuthorizationAttribute> newReaders = Optional.ofNullable(readers).map(ArrayList::new).orElse(new ArrayList<>());
+        newReaders.add(new AuthorizationAttribute(dataType, value));
+        return withReaders(newReaders);
+    }
+
+    public Authorization build() {
+        return new Authorization(admins, readers);
+    }
+}

--- a/fahrschein/src/main/java/org/zalando/fahrschein/AuthorizationBuilder.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/AuthorizationBuilder.java
@@ -3,33 +3,33 @@ package org.zalando.fahrschein;
 import org.zalando.fahrschein.domain.Authorization;
 import org.zalando.fahrschein.domain.Authorization.AuthorizationAttribute;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
+import static org.zalando.fahrschein.domain.Authorization.AuthorizationAttribute.ANYONE;
 
+/**
+ * Use factory method {@link AuthorizationBuilder#authorization()} to create
+ * an allow-all authorization object and use {@link #withAdmins} / {@link #withReaders}
+ * methods to override admins and/or readers lists.
+ */
 public class AuthorizationBuilder {
 
     private final List<AuthorizationAttribute> admins;
     private final List<AuthorizationAttribute> readers;
-
-    private AuthorizationBuilder() {
-        admins = null;
-        readers = null;
-    }
 
     private AuthorizationBuilder(List<AuthorizationAttribute> admins, List<AuthorizationAttribute> readers) {
         this.admins = admins;
         this.readers = readers;
     }
 
+    /**
+     * No restrictions by default, use {@link #withAdmins} / {@link #withReaders} methods to add them.
+     */
     public static AuthorizationBuilder authorization() {
-        return new AuthorizationBuilder();
-    }
-
-    public static Authorization notRestricted() {
-        return authorization().withAdmins(AuthorizationAttribute.ANYONE).withReaders(AuthorizationAttribute.ANYONE).build();
+        return new AuthorizationBuilder(singletonList(ANYONE), singletonList(ANYONE));
     }
 
     public AuthorizationBuilder withAdmins(List<AuthorizationAttribute> admins) {
@@ -49,13 +49,13 @@ public class AuthorizationBuilder {
     }
 
     public AuthorizationBuilder addAdmin(String dataType, String value) {
-        ArrayList<AuthorizationAttribute> newAdmins = Optional.ofNullable(admins).map(ArrayList::new).orElse(new ArrayList<>());
+        List<AuthorizationAttribute> newAdmins = admins.stream().filter(aa -> !aa.equals(ANYONE)).collect(toList());
         newAdmins.add(new AuthorizationAttribute(dataType, value));
         return withAdmins(newAdmins);
     }
 
     public AuthorizationBuilder addReader(String dataType, String value) {
-        ArrayList<AuthorizationAttribute> newReaders = Optional.ofNullable(readers).map(ArrayList::new).orElse(new ArrayList<>());
+        List<AuthorizationAttribute> newReaders = readers.stream().filter(aa -> !aa.equals(ANYONE)).collect(toList());;
         newReaders.add(new AuthorizationAttribute(dataType, value));
         return withReaders(newReaders);
     }

--- a/fahrschein/src/main/java/org/zalando/fahrschein/NakadiClient.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/NakadiClient.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.zalando.fahrschein.domain.Authorization;
 import org.zalando.fahrschein.domain.Cursor;
 import org.zalando.fahrschein.domain.Partition;
 import org.zalando.fahrschein.domain.Subscription;
@@ -119,11 +120,11 @@ public class NakadiClient {
 
     }
 
-    Subscription subscribe(String applicationName, Set<String> eventNames, String consumerGroup, SubscriptionRequest.Position readFrom, @Nullable List<Cursor> initialCursors) throws IOException {
+    Subscription subscribe(String applicationName, Set<String> eventNames, String consumerGroup, SubscriptionRequest.Position readFrom, @Nullable List<Cursor> initialCursors, @Nullable Authorization authorization) throws IOException {
 
         checkArgument(readFrom != SubscriptionRequest.Position.CURSORS || (initialCursors != null && !initialCursors.isEmpty()), "Initial cursors are required for position: cursors");
 
-        final SubscriptionRequest subscription = new SubscriptionRequest(applicationName, eventNames, consumerGroup, readFrom, initialCursors);
+        final SubscriptionRequest subscription = new SubscriptionRequest(applicationName, eventNames, consumerGroup, readFrom, initialCursors, authorization);
 
         final URI uri = baseUri.resolve("/subscriptions");
         final Request request = clientHttpRequestFactory.createRequest(uri, "POST");

--- a/fahrschein/src/main/java/org/zalando/fahrschein/SubscriptionBuilder.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/SubscriptionBuilder.java
@@ -1,5 +1,6 @@
 package org.zalando.fahrschein;
 
+import org.zalando.fahrschein.domain.Authorization;
 import org.zalando.fahrschein.domain.Cursor;
 import org.zalando.fahrschein.domain.Subscription;
 import org.zalando.fahrschein.domain.SubscriptionRequest;
@@ -22,41 +23,47 @@ public class SubscriptionBuilder {
     private final SubscriptionRequest.Position readFrom;
     @Nullable
     private final List<Cursor> initialCursors;
+    @Nullable
+    private final Authorization authorization;
 
     SubscriptionBuilder(NakadiClient nakadiClient, String applicationName, Set<String> eventNames) {
-        this(nakadiClient, applicationName, eventNames, DEFAULT_CONSUMER_GROUP, SubscriptionRequest.Position.END, null);
+        this(nakadiClient, applicationName, eventNames, DEFAULT_CONSUMER_GROUP, SubscriptionRequest.Position.END, null, null);
     }
 
-    private SubscriptionBuilder(NakadiClient nakadiClient, String applicationName, Set<String> eventNames, String consumerGroup, SubscriptionRequest.Position readFrom, @Nullable List<Cursor> initialCursors) {
+    private SubscriptionBuilder(NakadiClient nakadiClient, String applicationName, Set<String> eventNames, String consumerGroup, SubscriptionRequest.Position readFrom, @Nullable List<Cursor> initialCursors, @Nullable Authorization authorization) {
         this.nakadiClient = nakadiClient;
         this.applicationName = applicationName;
         this.eventNames = eventNames;
         this.consumerGroup = consumerGroup;
         this.readFrom = readFrom;
         this.initialCursors = initialCursors;
+        this.authorization = authorization;
     }
 
     public SubscriptionBuilder readFromBegin() {
         checkState(initialCursors == null, "Initial cursors can not be specified when reading from 'begin'");
-        return new SubscriptionBuilder(nakadiClient, applicationName, eventNames, consumerGroup, SubscriptionRequest.Position.BEGIN, null);
+        return new SubscriptionBuilder(nakadiClient, applicationName, eventNames, consumerGroup, SubscriptionRequest.Position.BEGIN, null, authorization);
     }
 
     public SubscriptionBuilder readFromEnd() {
         checkState(initialCursors == null, "Initial cursors can not be specified when reading from 'end'");
-        return new SubscriptionBuilder(nakadiClient, applicationName, eventNames, consumerGroup, SubscriptionRequest.Position.END, null);
+        return new SubscriptionBuilder(nakadiClient, applicationName, eventNames, consumerGroup, SubscriptionRequest.Position.END, null, authorization);
     }
 
     public SubscriptionBuilder readFromCursors(List<Cursor> initialCursors) {
         checkArgument(initialCursors != null, "Initial cursors have to be specified");
-        return new SubscriptionBuilder(nakadiClient, applicationName, eventNames, consumerGroup, SubscriptionRequest.Position.CURSORS, initialCursors);
+        return new SubscriptionBuilder(nakadiClient, applicationName, eventNames, consumerGroup, SubscriptionRequest.Position.CURSORS, initialCursors, authorization);
     }
 
     public SubscriptionBuilder withConsumerGroup(String consumerGroup) {
-        return new SubscriptionBuilder(nakadiClient, applicationName, eventNames, consumerGroup, readFrom, initialCursors);
+        return new SubscriptionBuilder(nakadiClient, applicationName, eventNames, consumerGroup, readFrom, initialCursors, authorization);
+    }
+
+    public SubscriptionBuilder withAuthorization(Authorization authorization) {
+        return new SubscriptionBuilder(nakadiClient, applicationName, eventNames, consumerGroup, readFrom, initialCursors, authorization);
     }
 
     public Subscription subscribe() throws IOException {
-        return nakadiClient.subscribe(applicationName, eventNames, consumerGroup, readFrom, initialCursors);
+        return nakadiClient.subscribe(applicationName, eventNames, consumerGroup, readFrom, initialCursors, authorization);
     }
-
 }

--- a/fahrschein/src/main/java/org/zalando/fahrschein/domain/Authorization.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/domain/Authorization.java
@@ -4,11 +4,13 @@ import javax.annotation.concurrent.Immutable;
 import java.util.List;
 import java.util.Objects;
 
+import static java.util.Collections.unmodifiableList;
+
 @Immutable
-public class Authorization {
+public final class Authorization {
 
     @Immutable
-    public static class AuthorizationAttribute {
+    public static final class AuthorizationAttribute {
 
         public static final AuthorizationAttribute ANYONE = new AuthorizationAttribute("*", "*");
 
@@ -49,8 +51,8 @@ public class Authorization {
     private final List<AuthorizationAttribute> readers;
 
     public Authorization(List<AuthorizationAttribute> admins, List<AuthorizationAttribute> readers) {
-        this.admins = admins;
-        this.readers = readers;
+        this.admins = unmodifiableList(admins);
+        this.readers = unmodifiableList(readers);
     }
 
     public List<AuthorizationAttribute> getAdmins() {

--- a/fahrschein/src/main/java/org/zalando/fahrschein/domain/Authorization.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/domain/Authorization.java
@@ -2,6 +2,7 @@ package org.zalando.fahrschein.domain;
 
 import javax.annotation.concurrent.Immutable;
 import java.util.List;
+import java.util.Objects;
 
 @Immutable
 public class Authorization {
@@ -25,6 +26,22 @@ public class Authorization {
 
         public String getValue() {
             return value;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o)
+                return true;
+            if (!(o instanceof AuthorizationAttribute))
+                return false;
+            AuthorizationAttribute that = (AuthorizationAttribute) o;
+            return dataType.equals(that.dataType) &&
+                    value.equals(that.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(dataType, value);
         }
     }
 

--- a/fahrschein/src/main/java/org/zalando/fahrschein/domain/Authorization.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/domain/Authorization.java
@@ -1,0 +1,46 @@
+package org.zalando.fahrschein.domain;
+
+import javax.annotation.concurrent.Immutable;
+import java.util.List;
+
+@Immutable
+public class Authorization {
+
+    @Immutable
+    public static class AuthorizationAttribute {
+
+        public static final AuthorizationAttribute ANYONE = new AuthorizationAttribute("*", "*");
+
+        private final String dataType;
+        private final String value;
+
+        public AuthorizationAttribute(String dataType, String value) {
+            this.dataType = dataType;
+            this.value = value;
+        }
+
+        public String getDataType() {
+            return dataType;
+        }
+
+        public String getValue() {
+            return value;
+        }
+    }
+
+    private final List<AuthorizationAttribute> admins;
+    private final List<AuthorizationAttribute> readers;
+
+    public Authorization(List<AuthorizationAttribute> admins, List<AuthorizationAttribute> readers) {
+        this.admins = admins;
+        this.readers = readers;
+    }
+
+    public List<AuthorizationAttribute> getAdmins() {
+        return admins;
+    }
+
+    public List<AuthorizationAttribute> getReaders() {
+        return readers;
+    }
+}

--- a/fahrschein/src/main/java/org/zalando/fahrschein/domain/Subscription.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/domain/Subscription.java
@@ -15,13 +15,15 @@ public class Subscription {
     private final Set<String> eventTypes;
     private final String consumerGroup;
     private final OffsetDateTime createdAt;
+    private final Authorization authorization;
 
-    public Subscription(String id, String owningApplication, Set<String> eventTypes, String consumerGroup, OffsetDateTime createdAt) {
+    public Subscription(String id, String owningApplication, Set<String> eventTypes, String consumerGroup, OffsetDateTime createdAt, Authorization authorization) {
         this.id = id;
         this.owningApplication = owningApplication;
         this.eventTypes = unmodifiableSet(eventTypes == null ? emptySet() : new HashSet<>(eventTypes));
         this.consumerGroup = consumerGroup;
         this.createdAt = createdAt;
+        this.authorization = authorization;
     }
 
 
@@ -43,5 +45,9 @@ public class Subscription {
 
     public OffsetDateTime getCreatedAt() {
         return createdAt;
+    }
+
+    public Authorization getAuthorization() {
+        return authorization;
     }
 }

--- a/fahrschein/src/main/java/org/zalando/fahrschein/domain/SubscriptionRequest.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/domain/SubscriptionRequest.java
@@ -2,6 +2,7 @@ package org.zalando.fahrschein.domain;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import java.util.*;
 
@@ -31,17 +32,19 @@ public class SubscriptionRequest {
     private final String consumerGroup;
     private final Position readFrom;
     private final List<Cursor> initialCursors;
+    private final Authorization authorization;
 
-    public SubscriptionRequest(String owningApplication, Set<String> eventTypes, String consumerGroup, Position readFrom, List<Cursor> initialCursors) {
+    public SubscriptionRequest(String owningApplication, @Nullable Set<String> eventTypes, String consumerGroup, Position readFrom, @Nullable List<Cursor> initialCursors, @Nullable Authorization authorization) {
         this.owningApplication = owningApplication;
         this.eventTypes = unmodifiableSet(eventTypes == null ? emptySet() : new HashSet<>(eventTypes));
         this.consumerGroup = consumerGroup;
         this.readFrom = readFrom;
         this.initialCursors = unmodifiableList((initialCursors == null) ? emptyList() : new ArrayList<>(initialCursors));
+        this.authorization = authorization;
     }
 
     public SubscriptionRequest(String owningApplication, Set<String> eventTypes, String consumerGroup) {
-        this(owningApplication, eventTypes, consumerGroup, Position.END, emptyList());
+        this(owningApplication, eventTypes, consumerGroup, Position.END, emptyList(), null);
     }
 
     public String getOwningApplication() {
@@ -62,5 +65,9 @@ public class SubscriptionRequest {
 
     public List<Cursor> getInitialCursors() {
         return initialCursors;
+    }
+
+    public Authorization getAuthorization() {
+        return authorization;
     }
 }

--- a/fahrschein/src/test/java/org/zalando/fahrschein/ManagedCursorManagerTest.java
+++ b/fahrschein/src/test/java/org/zalando/fahrschein/ManagedCursorManagerTest.java
@@ -38,7 +38,7 @@ public class ManagedCursorManagerTest {
                 .andRespondWith(204)
                 .setup();
 
-        final Subscription subscription = new Subscription("1234", "nakadi-client-test", Collections.singleton("foo"), "bar", OffsetDateTime.now());
+        final Subscription subscription = new Subscription("1234", "nakadi-client-test", Collections.singleton("foo"), "bar", OffsetDateTime.now(), null);
         cursorManager.addSubscription(subscription);
         cursorManager.addStreamId(subscription, "stream-id");
 
@@ -53,7 +53,7 @@ public class ManagedCursorManagerTest {
                 .andRespondWith(200, ContentType.APPLICATION_JSON, "{\"items\":[{\"partition\":\"0\",\"offset\":\"10\"},{\"partition\":\"1\",\"offset\":\"20\"}]}")
                 .setup();
 
-        final Subscription subscription = new Subscription("1234", "nakadi-client-test", Collections.singleton("foo"), "bar", OffsetDateTime.now());
+        final Subscription subscription = new Subscription("1234", "nakadi-client-test", Collections.singleton("foo"), "bar", OffsetDateTime.now(), null);
         cursorManager.addSubscription(subscription);
 
         final Collection<Cursor> cursors = cursorManager.getCursors("foo");


### PR DESCRIPTION
Fixes #234

This is absolutely a must for environments that don't support creating unauthorized subscriptions.

Tested locally with the Zalando internal Nakadi, works good.