### PR TITLE
Allow any type of authorization type

### DIFF
--- a/fahrschein/src/main/java/org/zalando/fahrschein/AccessTokenProvider.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/AccessTokenProvider.java
@@ -2,6 +2,11 @@ package org.zalando.fahrschein;
 
 import java.io.IOException;
 
-public interface AccessTokenProvider {
+public interface AccessTokenProvider extends AuthorizationProvider {
     String getAccessToken() throws IOException;
+
+    @Override
+    default String getAuthorizationHeader() throws IOException {
+        return "Bearer " + getAccessToken();
+    }
 }

--- a/fahrschein/src/main/java/org/zalando/fahrschein/AuthorizationProvider.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/AuthorizationProvider.java
@@ -1,0 +1,7 @@
+package org.zalando.fahrschein;
+
+import java.io.IOException;
+
+public interface AuthorizationProvider {
+    String getAuthorizationHeader() throws IOException;
+}

--- a/fahrschein/src/main/java/org/zalando/fahrschein/AuthorizedRequestFactory.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/AuthorizedRequestFactory.java
@@ -3,23 +3,22 @@ package org.zalando.fahrschein;
 import org.zalando.fahrschein.http.api.Headers;
 import org.zalando.fahrschein.http.api.Request;
 import org.zalando.fahrschein.http.api.RequestFactory;
-
 import java.io.IOException;
 import java.net.URI;
 
 class AuthorizedRequestFactory implements RequestFactory {
     private final RequestFactory delegate;
-    private final AccessTokenProvider accessTokenProvider;
+    private final AuthorizationProvider authorizationProvider;
 
-    public AuthorizedRequestFactory(final RequestFactory delegate, final AccessTokenProvider accessTokenProvider) {
+    AuthorizedRequestFactory(final RequestFactory delegate, final AuthorizationProvider authorizationProvider) {
         this.delegate = delegate;
-        this.accessTokenProvider = accessTokenProvider;
+        this.authorizationProvider = authorizationProvider;
     }
 
     @Override
     public Request createRequest(URI uri, String method) throws IOException {
         final Request request = delegate.createRequest(uri, method);
-        request.getHeaders().put(Headers.AUTHORIZATION, "Bearer ".concat(accessTokenProvider.getAccessToken()));
+        request.getHeaders().put(Headers.AUTHORIZATION, authorizationProvider.getAuthorizationHeader());
         return request;
     }
 }

--- a/fahrschein/src/main/java/org/zalando/fahrschein/ManagedCursorManager.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/ManagedCursorManager.java
@@ -11,7 +11,6 @@ import org.zalando.fahrschein.http.api.ContentType;
 import org.zalando.fahrschein.http.api.Request;
 import org.zalando.fahrschein.http.api.RequestFactory;
 import org.zalando.fahrschein.http.api.Response;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -21,8 +20,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static java.util.Collections.singletonList;
 import static org.zalando.fahrschein.NakadiClientBuilder.wrapClientHttpRequestFactory;
+import static java.util.Collections.singletonList;
 
 public class ManagedCursorManager implements CursorManager {
 
@@ -73,8 +72,8 @@ public class ManagedCursorManager implements CursorManager {
     private final ObjectMapper objectMapper;
     private final Map<String, SubscriptionStream> streams;
 
-    public ManagedCursorManager(URI baseUri, RequestFactory clientHttpRequestFactory, AccessTokenProvider accessTokenProvider) {
-        this(baseUri, wrapClientHttpRequestFactory(clientHttpRequestFactory, accessTokenProvider), true);
+    public ManagedCursorManager(URI baseUri, RequestFactory clientHttpRequestFactory, AuthorizationProvider authorizationProvider) {
+        this(baseUri, wrapClientHttpRequestFactory(clientHttpRequestFactory, authorizationProvider), true);
     }
 
     public ManagedCursorManager(URI baseUri, RequestFactory clientHttpRequestFactory) {

--- a/fahrschein/src/test/java/org/zalando/fahrschein/AccessTokenProviderTest.java
+++ b/fahrschein/src/test/java/org/zalando/fahrschein/AccessTokenProviderTest.java
@@ -1,0 +1,17 @@
+package org.zalando.fahrschein;
+
+import org.junit.Test;
+import java.io.IOException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+public class AccessTokenProviderTest {
+
+    @Test
+    public void shouldAdaptToBearerAuthorizationProvider() throws IOException {
+        final String token = "token";
+        final AuthorizationProvider provider = (AccessTokenProvider) () -> token;
+        assertThat(provider.getAuthorizationHeader(), equalTo("Bearer " + token));
+    }
+}

--- a/fahrschein/src/test/java/org/zalando/fahrschein/AuthorizedRequestFactoryTest.java
+++ b/fahrschein/src/test/java/org/zalando/fahrschein/AuthorizedRequestFactoryTest.java
@@ -1,0 +1,55 @@
+package org.zalando.fahrschein;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.zalando.fahrschein.http.api.Headers;
+import org.zalando.fahrschein.http.api.HeadersImpl;
+import org.zalando.fahrschein.http.api.Request;
+import org.zalando.fahrschein.http.api.RequestFactory;
+import java.io.IOException;
+import java.net.URI;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class AuthorizedRequestFactoryTest {
+
+    private static final String BEARER_TOKEN = "Bearer token";
+    private final RequestFactory delegate = mock(RequestFactory.class);
+    private final AuthorizedRequestFactory unit = new AuthorizedRequestFactory(delegate, () -> BEARER_TOKEN);
+
+    @Before
+    public void setUp() throws Exception {
+        final Request request = mockRequest();
+        when(delegate.createRequest(any(), anyString())).thenReturn(request);
+    }
+
+    @Test
+    public void shouldDelegate() throws IOException {
+        final URI uri = URI.create("localhost");
+        final String method = "GET";
+
+        unit.createRequest(uri, method);
+        verify(delegate).createRequest(uri, method);
+    }
+
+    @Test
+    public void shouldAddAuthorizationHeader() throws IOException {
+        final Request request = unit.createRequest(URI.create("localhost"), "POST");
+        assertThat(request.getHeaders().headerNames(), contains(Headers.AUTHORIZATION));
+        assertThat(request.getHeaders().getFirst(Headers.AUTHORIZATION), equalTo(BEARER_TOKEN));
+    }
+
+
+    private static Request mockRequest() {
+        final Request request = mock(Request.class);
+        when(request.getHeaders()).thenReturn(new HeadersImpl());
+        return request;
+    }
+}


### PR DESCRIPTION
Right now the `AuthorizedRequestFactory` is hardwired to `Bearer` authorization, by prefixing it to whatever the `AccessTokenProvider` provides. In this change we introduce a new `AuthorizationProvider` interface providing the whole authorization string, allowing users to choose freely.

* add new AuthorizationProvider interface providing full authorization string
* add adapter for AccessTokenProvider
* extend public interfaces with new provider