### PR TITLE
toString method for MetaData

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 jdk:
   - oraclejdk8
 install: true
+dist: trusty
 env:
   matrix:
     - VERSION_JACKSON='-Dversion.jackson=2.6.7' PROJECTS='-pl !fahrschein-typeresolver,!fahrschein-example'

--- a/fahrschein/src/main/java/org/zalando/fahrschein/domain/Metadata.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/domain/Metadata.java
@@ -64,4 +64,15 @@ public final class Metadata {
     public Map<String, String> getSpanCtx() {
         return spanCtx;
     }
+
+    @Override
+    public String toString() {
+        return "Metadata{" +
+                "eventType='" + eventType + '\'' +
+                ", eid='" + eid + '\'' +
+                ", occurredAt=" + occurredAt +
+                ", receivedAt=" + receivedAt +
+                ", flowId='" + flowId + '\'' +
+                '}';
+    }
 }

--- a/fahrschein/src/test/java/org/zalando/fahrschein/domain/MetadataTest.java
+++ b/fahrschein/src/test/java/org/zalando/fahrschein/domain/MetadataTest.java
@@ -19,13 +19,10 @@ public class MetadataTest {
 
         final Metadata metadata = new Metadata(eventType, eid, occurredAt, receivedAt, flowId, Collections.emptyMap());
 
-        Assert.assertEquals(metadata.toString(),
-                "Metadata{" +
-                        "eventType='" + metadata.getEventType() + '\'' +
-                        ", eid='" + metadata.getEid() + '\'' +
-                        ", occurredAt=" + metadata.getOccurredAt() +
-                        ", receivedAt=" + metadata.getReceivedAt() +
-                        ", flowId='" + metadata.getFlowId() + '\'' +
-                        '}');
+        Assert.assertTrue(metadata.toString().contains(metadata.getEventType()));
+        Assert.assertTrue(metadata.toString().contains(metadata.getEid()));
+        Assert.assertTrue(metadata.toString().contains(metadata.getOccurredAt().toString()));
+        Assert.assertTrue(metadata.toString().contains(metadata.getReceivedAt().toString()));
+        Assert.assertTrue(metadata.toString().contains(metadata.getFlowId()));
     }
 }

--- a/fahrschein/src/test/java/org/zalando/fahrschein/domain/MetadataTest.java
+++ b/fahrschein/src/test/java/org/zalando/fahrschein/domain/MetadataTest.java
@@ -1,0 +1,31 @@
+package org.zalando.fahrschein.domain;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.time.OffsetDateTime;
+import java.util.Collections;
+import java.util.UUID;
+
+public class MetadataTest {
+
+    @Test
+    public void shouldHaveCleanStringRepresentation() {
+        final String eventType = "TEST-EVENT-TYPE";
+        final String eid = "a3e25946-5ae9-3964-91fa-26ecb7588d67";
+        final OffsetDateTime occurredAt = OffsetDateTime.now();
+        final OffsetDateTime receivedAt = OffsetDateTime.now();
+        final String flowId = UUID.randomUUID().toString();
+
+        final Metadata metadata = new Metadata(eventType, eid, occurredAt, receivedAt, flowId, Collections.emptyMap());
+
+        Assert.assertEquals(metadata.toString(),
+                "Metadata{" +
+                        "eventType='" + metadata.getEventType() + '\'' +
+                        ", eid='" + metadata.getEid() + '\'' +
+                        ", occurredAt=" + metadata.getOccurredAt() +
+                        ", receivedAt=" + metadata.getReceivedAt() +
+                        ", flowId='" + metadata.getFlowId() + '\'' +
+                        '}');
+    }
+}


### PR DESCRIPTION
* added toString method for MetaData to get a string representation of such objects in logs
* added "dist: trusty" to .travis.yml to be able to use oraclejdk8 further. Otherwise we need to change jdk  to oraclejdk8, for example.