### PR TITLE
Exception while the cursor is being committed

### DIFF
--- a/fahrschein/src/main/java/org/zalando/fahrschein/ProblemHandlingRequest.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/ProblemHandlingRequest.java
@@ -41,7 +41,7 @@ class ProblemHandlingRequest implements Request {
                 final Headers headers = response.getHeaders();
                 final ContentType contentType = headers.getContentType();
 
-                if (mightBeProblematic(contentType)) {
+                if (contentType == null || mightBeProblematic(contentType)) {
 
                     final JsonNode json = objectMapper.readTree(response.getBody());
 


### PR DESCRIPTION
close #250.

### Solution

The solution adopted in this PR is to allow `fahrschein` to parse the content of the response from Nakadi even if the response ContentType is null.

With this fix, the `NullPointerException` is avoided. A different exception might be thrown during the parsing but such exception will be caught by the surrounding try-catch as usual.