### PR TITLE
Log 'info.debug' from 'Batch' in NakadiReader instead of skipping it

### DIFF
--- a/fahrschein/src/main/java/org/zalando/fahrschein/NakadiReader.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/NakadiReader.java
@@ -260,6 +260,22 @@ class NakadiReader<T> implements IORunnable {
         return new Cursor(partition, offset, eventType, cursorToken);
     }
 
+    private void logInfo(JsonParser parser) throws IOException {
+        expectToken(parser, JsonToken.START_OBJECT);
+        while(parser.nextToken() != JsonToken.END_OBJECT) {
+            final String x = parser.getCurrentName();
+            switch (x) {
+                case "debug":
+                    LOG.info("STREAM DEBUG: {}", parser.nextTextValue());
+                    break;
+                default:
+                    parser.nextToken();
+                    parser.skipChildren();
+                    break;
+            }
+        }
+    }
+
     @Override
     public void run() throws IOException {
         try {
@@ -369,9 +385,7 @@ class NakadiReader<T> implements IORunnable {
                     break;
                 }
                 case "info": {
-                    LOG.debug("Skipping stream info in event batch");
-                    jsonParser.nextToken();
-                    jsonParser.skipChildren();
+                    logInfo(jsonParser);
                     break;
                 }
                 default: {


### PR DESCRIPTION
'Nakadi' uses 'info' section in each 'Batch' to give a hint about the state of the stream. 
Current implementation of 'NakadiReader' ignore it completely, while in our experience we found that those hints help to debug consuming problems. This PR includes small changes to log the 'info.debug' value instead of skipping it. 