### PR TITLE
Issues/254 commit offset error msg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 .idea
 target/
 *.iml
+
+#vscode
+.project
+.classpath
+.factorypath
+.settings/

--- a/fahrschein/src/main/java/org/zalando/fahrschein/CursorCommitException.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/CursorCommitException.java
@@ -6,38 +6,40 @@ import java.util.Optional;
 import org.zalando.fahrschein.domain.Cursor;
 
 @SuppressWarnings("serial")
-public class CursorOffsetCommitException extends IOException {
+public class CursorCommitException extends IOException {
     private final int statusCode;
     private final Cursor cursor;
     private final String subscriptionId;
 
-    public CursorOffsetCommitException(int statusCode, Cursor cursor, String subscriptionId, IOException cause) {
-        super(formatMessage(statusCode, cursor, subscriptionId), cause);
+    public CursorCommitException(int statusCode, Cursor cursor, String subscriptionId, IOException cause) {
+        super(formatMessage(statusCode, cursor, subscriptionId, Optional.empty()), cause);
         this.statusCode = statusCode;
         this.cursor = cursor;
         this.subscriptionId = subscriptionId;
     }
 
-    public CursorOffsetCommitException(int statusCode, Cursor cursor, String subscriptionId) {
-        super(formatMessage(statusCode, cursor, subscriptionId));
+    public CursorCommitException(int statusCode, Cursor cursor, String subscriptionId, String responseBody) {
+        super(formatMessage(statusCode, cursor, subscriptionId, Optional.of(responseBody)));
         this.statusCode = statusCode;
         this.cursor = cursor;
         this.subscriptionId = subscriptionId;
     }
 
-    private static String formatMessage(int statusCode, Cursor cursor, String subscriptionId) {
+    private static String formatMessage(int statusCode, Cursor cursor, String subscriptionId, Optional<String> responseBody) {
         String msg;
         switch (statusCode) {
             case 422:
                 msg = String.format(
-                    "Cursor for subscription [%s] to event [%s] in partition [%s] with offset [%s] failed to commit because of error 422 (Unprocessable Entity). " +
+                    "Cursor for subscription [%s] and event type [%s] in partition [%s] with offset [%s] failed to commit because of status code 422 (Unprocessable Entity). " +
                     "This likely means that the processing time of the batch exceeded the timeout (defaults to 60 seconds). " + 
                     "In such case, you may want to investigate the slowness in the processing, and/or reduce the batch size.", 
-                    nullSafe(subscriptionId), nullSafe(cursor.getEventType()), cursor.getPartition(), cursor.getOffset());
+                    nullSafe(subscriptionId), nullSafe(cursor.getEventType()), cursor.getPartition(), cursor.getOffset()) +
+                    responseBody.map(s -> String.format(" Response body: [%s]", s)).orElse("");
                 break;
             default: 
-                msg = String.format("Unexpected status code [%s] for subscription [%s] to event [%s]", 
-                                    statusCode, subscriptionId, nullSafe(cursor.getEventType()));
+                msg = String.format("Unexpected status code [%s] for subscription [%s] to event [%s].", 
+                                    statusCode, subscriptionId, nullSafe(cursor.getEventType())) +
+                    responseBody.map(s -> String.format(" Response body: [%s]", s)).orElse("");
                 break;
         }
         return msg;

--- a/fahrschein/src/main/java/org/zalando/fahrschein/CursorOffsetCommitException.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/CursorOffsetCommitException.java
@@ -31,7 +31,7 @@ public class CursorOffsetCommitException extends IOException {
             case 422:
                 msg = String.format(
                     "Cursor for subscription [%s] to event [%s] in partition [%s] with offset [%s] failed to commit because of error 422 (Unprocessable Entity). " +
-                    "This likely means that the processing time of the batch exceeded the timeout of 60 seconds. " + 
+                    "This likely means that the processing time of the batch exceeded the timeout (defaults to 60 seconds). " + 
                     "In such case, you may want to investigate the slowness in the processing, and/or reduce the batch size.", 
                     nullSafe(subscriptionId), nullSafe(cursor.getEventType()), cursor.getPartition(), cursor.getOffset());
                 break;

--- a/fahrschein/src/main/java/org/zalando/fahrschein/CursorOffsetCommitException.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/CursorOffsetCommitException.java
@@ -11,6 +11,13 @@ public class CursorOffsetCommitException extends IOException {
     private final Cursor cursor;
     private final String subscriptionId;
 
+    public CursorOffsetCommitException(int statusCode, Cursor cursor, String subscriptionId, IOException cause) {
+        super(formatMessage(statusCode, cursor, subscriptionId), cause);
+        this.statusCode = statusCode;
+        this.cursor = cursor;
+        this.subscriptionId = subscriptionId;
+    }
+
     public CursorOffsetCommitException(int statusCode, Cursor cursor, String subscriptionId) {
         super(formatMessage(statusCode, cursor, subscriptionId));
         this.statusCode = statusCode;

--- a/fahrschein/src/main/java/org/zalando/fahrschein/CursorOffsetCommitException.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/CursorOffsetCommitException.java
@@ -1,0 +1,51 @@
+package org.zalando.fahrschein;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import org.zalando.fahrschein.domain.Cursor;
+
+@SuppressWarnings("serial")
+public class CursorOffsetCommitException extends IOException {
+    private final int statusCode;
+    private final Cursor cursor;
+    private final String subscriptionId;
+
+    public CursorOffsetCommitException(int statusCode, Cursor cursor, String subscriptionId) {
+        super(formatMessage(statusCode, cursor, subscriptionId));
+        this.statusCode = statusCode;
+        this.cursor = cursor;
+        this.subscriptionId = subscriptionId;
+    }
+
+    private static String formatMessage(int statusCode, Cursor cursor, String subscriptionId) {
+        String msg;
+        switch (statusCode) {
+            case 422:
+                msg = String.format("Cursor for subscription [%s] to event [%s] in partition [%s] with offset [%s] failed to commit because of error 422 (Unprocessable Entity). This likely means that the processing time of the batch exceeded the timeout of 60 seconds. In such case, you may want to investigate the slowness in the processing, and/or reduce the batch size", 
+                                    nullSafe(subscriptionId), nullSafe(cursor.getEventType()), cursor.getPartition(), cursor.getOffset());
+                break;
+            default: 
+                msg = String.format("Unexpected status code [%s] for subscription [%s] to event [%s]", 
+                                    statusCode, subscriptionId, nullSafe(cursor.getEventType()));
+                break;
+        }
+        return msg;
+    }
+
+    private static String nullSafe(String s) {
+        return Optional.ofNullable(s).orElse("");
+    }
+
+    public Cursor getCursor() {
+        return cursor;
+    }
+
+    public String getSubscriptionId() {
+        return subscriptionId;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+}

--- a/fahrschein/src/main/java/org/zalando/fahrschein/CursorOffsetCommitException.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/CursorOffsetCommitException.java
@@ -29,8 +29,11 @@ public class CursorOffsetCommitException extends IOException {
         String msg;
         switch (statusCode) {
             case 422:
-                msg = String.format("Cursor for subscription [%s] to event [%s] in partition [%s] with offset [%s] failed to commit because of error 422 (Unprocessable Entity). This likely means that the processing time of the batch exceeded the timeout of 60 seconds. In such case, you may want to investigate the slowness in the processing, and/or reduce the batch size", 
-                                    nullSafe(subscriptionId), nullSafe(cursor.getEventType()), cursor.getPartition(), cursor.getOffset());
+                msg = String.format(
+                    "Cursor for subscription [%s] to event [%s] in partition [%s] with offset [%s] failed to commit because of error 422 (Unprocessable Entity). " +
+                    "This likely means that the processing time of the batch exceeded the timeout of 60 seconds. " + 
+                    "In such case, you may want to investigate the slowness in the processing, and/or reduce the batch size.", 
+                    nullSafe(subscriptionId), nullSafe(cursor.getEventType()), cursor.getPartition(), cursor.getOffset());
                 break;
             default: 
                 msg = String.format("Unexpected status code [%s] for subscription [%s] to event [%s]", 

--- a/fahrschein/src/main/java/org/zalando/fahrschein/ManagedCursorManager.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/ManagedCursorManager.java
@@ -134,7 +134,7 @@ public class ManagedCursorManager implements CursorManager {
         } catch (IOProblem e) {
             // in order to not have to refactor the entire ProblemHandlingRequest class,
             // we are catching the error here and re-throwing a more specific one
-            throw new CursorOffsetCommitException(e.getStatusCode(), cursor, subscriptionId);
+            throw new CursorOffsetCommitException(e.getStatusCode(), cursor, subscriptionId, e);
         }
     }
 

--- a/fahrschein/src/main/java/org/zalando/fahrschein/ManagedCursorManager.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/ManagedCursorManager.java
@@ -129,8 +129,12 @@ public class ManagedCursorManager implements CursorManager {
             } else if (status == 200) {
                 LOG.warn("Cursor for subscription [{}] to event [{}] in partition [{}] with offset [{}] was already committed", subscriptionId, eventName, cursor.getPartition(), cursor.getOffset());
             } else {
-                throw new IOException(String.format("Unexpected status code [%s] for subscription [%s] to event [%s]", status, subscriptionId, eventName));
+                throw new CursorOffsetCommitException(status, cursor, subscriptionId);
             }
+        } catch (IOProblem e) {
+            // in order to not have to refactor the entire ProblemHandlingRequest class,
+            // we are catching the error here and re-throwing a more specific one
+            throw new CursorOffsetCommitException(e.getStatusCode(), cursor, subscriptionId);
         }
     }
 

--- a/fahrschein/src/test/java/org/zalando/fahrschein/ManagedCursorManagerTest.java
+++ b/fahrschein/src/test/java/org/zalando/fahrschein/ManagedCursorManagerTest.java
@@ -17,6 +17,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class ManagedCursorManagerTest {
     private MockServer server;
@@ -45,6 +46,34 @@ public class ManagedCursorManagerTest {
         cursorManager.onSuccess("foo", new Cursor("0", "10", "foo", "token"));
 
         server.verify();
+    }
+
+    @Test
+    public void shouldThrowCursorOffsetCommitExceptionWhenServerReturnsError() throws IOException {
+        int errorCode = 422;
+        String streamId = "stream-id";
+        server.expectRequestTo("http://example.com/subscriptions/1234/cursors", "POST")
+                .andExpectHeader("X-Nakadi-StreamId", streamId)
+                .andExpectJsonPath("$.items[0].partition", equalTo("0"))
+                .andExpectJsonPath("$.items[0].offset", equalTo("10"))
+                .andExpectJsonPath("$.items[0].cursor_token", equalTo("token"))
+                .andRespondWith(errorCode, ContentType.TEXT_PLAIN, "Session with stream id " + streamId + " not found")
+                .setup();
+
+        final Subscription subscription = new Subscription("1234", "nakadi-client-test", Collections.singleton("foo"), "bar", OffsetDateTime.now(), null);
+        cursorManager.addSubscription(subscription);
+        cursorManager.addStreamId(subscription, streamId);
+        Cursor cursor = new Cursor("0", "10", "foo", "token");
+        try {
+            cursorManager.onSuccess("foo", cursor);
+            fail(CursorOffsetCommitException.class + " was not thrown");
+        } catch (CursorOffsetCommitException e) {
+            assertEquals(errorCode, e.getStatusCode());
+            assertEquals(cursor, e.getCursor());
+            assertEquals(subscription.getId(), e.getSubscriptionId());
+        } finally {
+            server.verify();
+        }
     }
 
     @Test


### PR DESCRIPTION
Addressing https://github.com/zalando-nakadi/fahrschein/issues/254

For cursor offset commit timeouts, instead of:
```
org.zalando.fahrschein.IOProblem: Problem [about:blank] with status [422]: [Unprocessable Entity] [Session with stream id zzz not found]
```
we will get
```
org.zalando.fahrschein.CursorOffsetCommitException: Cursor for subscription [sss] to event [eee] in partition [p] with offset [ooo] failed to commit because of error 422 (Unprocessable Entity). This likely means that the processing time of the batch exceeded the timeout of 60 seconds. In such case, you may want to investigate the slowness in the processing, and/or reduce the batch size
org.zalando.fahrschein.IOProblem: Problem [about:blank] with status [422]: [Unprocessable Entity] [Session with stream id zzz not found]
``` 

Some remarks: I decided to not add more logic to ProblemHandlingRequest ([example](https://github.com/zalando-nakadi/fahrschein/blob/master/fahrschein/src/main/java/org/zalando/fahrschein/ProblemHandlingRequest.java#L82)), because parsing the response body to determine the error type is far from ideal. Instead, we catch and re-throw a specific exception where the error occurs.