### PR TITLE
Ensure 4-eyes principle

### DIFF
--- a/.zappr.yaml
+++ b/.zappr.yaml
@@ -1,8 +1,9 @@
+# for github.com
 approvals:
-  pattern: "^(:\\+1:|:thumbsup:|[Ll][Gg][Tt][Mm])$"
-  minimum: 1
-  from:
-    orgs:
-      - zalando
-      - zalando-incubator
-    collaborators: true
+  groups:
+    zalando:
+      minimum: 2
+      from:
+        orgs:
+          - zalando
+


### PR DESCRIPTION
~~The current zappr configuration doesn't enforce 4-eyes principle, fixing it.~~

Apparently the current zappr configuration does seem to enforce 4-eyes as I cannot thumb-up my own PR. So, this commit is just cleaning up and inserting the zappr defaults, which should be: two thumbs-up needed by authorized members, but author can +1 himself.
