### PR TITLE
Deprecate external Cursor management

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,16 @@ cursorManager.fromNewestAvailableOffsets(eventName, partitions);
 cursorManager.updatePartitions(eventName, partitions);
 ```
 
-## Using the low-level api
+## Using Nakadi's Low-level API
 
-*Please do not use the low-level api, as it is deprecated.*
+*Please do not use the Low-level API, as it is deprecated by Nakadi.*
 
-The low-level api requires local persistence of partition offsets. There are persistent `CursorManager` implementations using either Postgres or Redis.
+The Low-level API requires local persistence of partition offsets.
+There are currently three persistent `CursorManager` implementations: InMemory, Postgres and Redis.
+
+!!! warning
+    Postgres and Redis cursor managers are DEPRECATED and will be
+    removed in an upcoming version of Fahrschein.
 
 ```java
 final HikariConfig hikariConfig = new HikariConfig();

--- a/fahrschein-jdbc/src/main/java/org/zalando/fahrschein/jdbc/JdbcCursorManager.java
+++ b/fahrschein-jdbc/src/main/java/org/zalando/fahrschein/jdbc/JdbcCursorManager.java
@@ -14,6 +14,11 @@ import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
 import static org.zalando.fahrschein.Preconditions.checkState;
 
+/**
+ * Deprecated for removal. Externally managing Nakadi cursors is not recommended
+ * practice, not useful, and not really seen in the field.
+ */
+@Deprecated
 public class JdbcCursorManager implements CursorManager {
 
     private static final String FIND_BY_EVENT_NAME = "SELECT * FROM %snakadi_cursor_find_by_event_name(?, ?)";

--- a/fahrschein-redis/src/main/java/org/zalando/fahrschein/redis/RedisCursorManager.java
+++ b/fahrschein-redis/src/main/java/org/zalando/fahrschein/redis/RedisCursorManager.java
@@ -12,6 +12,11 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
+/**
+ * Deprecated for removal. Externally managing Nakadi cursors is not recommended
+ * practice, not useful, and not really seen in the field.
+ */
+@Deprecated
 public class RedisCursorManager implements CursorManager {
     private static final Logger LOG = LoggerFactory.getLogger(RedisCursorManager.class);
 


### PR DESCRIPTION
Nakadi's low-level API has one use-case: if you always want to read a
topic from the beginning. This is incompatible with the idea of an
external persistant storage for offsets. If offset persistance is
needed, people should use the normal subscription APIs.

This commit marks the JDBC and Redis implementations as deprecated, so
that we can remove them in a future release.

Signed-off-by: Oliver <oliver.trosien@zalando.de>