### PR TITLE
JavaNet RequestFactory implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,17 @@ nakadiClient.stream(eventName)
 
 Fahrschein uses it's own http abstraction which is very similar to spring framework's [`ClientHttpRequestFactory`](http://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/http/client/ClientHttpRequestFactory.html) interface. By default it uses the `SimpleRequestFactory` which uses a `HttpURLConnection` internally and has no further dependencies.
 
+
+There is a version using java.net HttpClient (JDK11+) named `JavaNetRequestFactory` in the `fahrschein-http-jdk11` artifact.
+
+```xml
+<dependency>
+    <groupId>org.zalando</groupId>
+    <artifactId>fahrschein-http-jdk11</artifactId>
+    <version>${fahrschein.version}</version>
+</dependency>
+```
+
 There is also a version using apache http components named `HttpComponentsRequestFactory` in the `fahrschein-http-apache` artifact.
 
 ```xml

--- a/fahrschein-e2e-test/pom.xml
+++ b/fahrschein-e2e-test/pom.xml
@@ -3,6 +3,18 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>11</source>
+                    <target>11</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <parent>
         <groupId>org.zalando</groupId>
@@ -36,6 +48,12 @@
         <dependency>
             <groupId>org.zalando</groupId>
             <artifactId>fahrschein-http-spring</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.zalando</groupId>
+            <artifactId>fahrschein-http-jdk11</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>

--- a/fahrschein-e2e-test/src/test/java/org/zalando/fahrschein/http/AbstractRequestFactoryTest.java
+++ b/fahrschein-e2e-test/src/test/java/org/zalando/fahrschein/http/AbstractRequestFactoryTest.java
@@ -26,6 +26,9 @@ import java.util.stream.IntStream;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.*;
 
+/*
+ * Enable wire-debug by running with -Djdk.httpclient.HttpClient.log=requests
+ */
 public abstract class AbstractRequestFactoryTest extends NakadiTestWithDockerCompose {
 
     private static ObjectMapper objectMapper = new ObjectMapper();

--- a/fahrschein-e2e-test/src/test/java/org/zalando/fahrschein/http/jdk11/IdentityEncodingJavaNetNakadiClientTest.java
+++ b/fahrschein-e2e-test/src/test/java/org/zalando/fahrschein/http/jdk11/IdentityEncodingJavaNetNakadiClientTest.java
@@ -11,6 +11,6 @@ import java.time.Duration;
 public class IdentityEncodingJavaNetNakadiClientTest extends AbstractRequestFactoryTest {
     @Override
     protected RequestFactory getRequestFactory() {
-        return new IdentityAcceptEncodingRequestFactory(new JavaNetRequestFactory(HttpClient.newBuilder().build(), rb -> rb.timeout(Duration.ofSeconds(1)), ContentEncoding.IDENTITY));
+        return new IdentityAcceptEncodingRequestFactory(new JavaNetRequestFactory(HttpClient.newBuilder().build(), Duration.ofSeconds(1), ContentEncoding.IDENTITY));
     }
 }

--- a/fahrschein-e2e-test/src/test/java/org/zalando/fahrschein/http/jdk11/IdentityEncodingJavaNetNakadiClientTest.java
+++ b/fahrschein-e2e-test/src/test/java/org/zalando/fahrschein/http/jdk11/IdentityEncodingJavaNetNakadiClientTest.java
@@ -7,10 +7,11 @@ import org.zalando.fahrschein.http.api.RequestFactory;
 
 import java.net.http.HttpClient;
 import java.time.Duration;
+import java.util.Optional;
 
 public class IdentityEncodingJavaNetNakadiClientTest extends AbstractRequestFactoryTest {
     @Override
     protected RequestFactory getRequestFactory() {
-        return new IdentityAcceptEncodingRequestFactory(new JavaNetRequestFactory(HttpClient.newBuilder().build(), Duration.ofSeconds(1), ContentEncoding.IDENTITY));
+        return new IdentityAcceptEncodingRequestFactory(new JavaNetRequestFactory(HttpClient.newBuilder().build(), Optional.of(Duration.ofSeconds(1)), ContentEncoding.IDENTITY));
     }
 }

--- a/fahrschein-e2e-test/src/test/java/org/zalando/fahrschein/http/jdk11/IdentityEncodingJavaNetNakadiClientTest.java
+++ b/fahrschein-e2e-test/src/test/java/org/zalando/fahrschein/http/jdk11/IdentityEncodingJavaNetNakadiClientTest.java
@@ -1,0 +1,16 @@
+package org.zalando.fahrschein.http.jdk11;
+
+import org.zalando.fahrschein.IdentityAcceptEncodingRequestFactory;
+import org.zalando.fahrschein.http.AbstractRequestFactoryTest;
+import org.zalando.fahrschein.http.api.ContentEncoding;
+import org.zalando.fahrschein.http.api.RequestFactory;
+
+import java.net.http.HttpClient;
+import java.time.Duration;
+
+public class IdentityEncodingJavaNetNakadiClientTest extends AbstractRequestFactoryTest {
+    @Override
+    protected RequestFactory getRequestFactory() {
+        return new IdentityAcceptEncodingRequestFactory(new JavaNetRequestFactory(HttpClient.newBuilder().build(), rb -> rb.timeout(Duration.ofSeconds(1)), ContentEncoding.IDENTITY));
+    }
+}

--- a/fahrschein-e2e-test/src/test/java/org/zalando/fahrschein/http/jdk11/JavaNetNakadiClientTest.java
+++ b/fahrschein-e2e-test/src/test/java/org/zalando/fahrschein/http/jdk11/JavaNetNakadiClientTest.java
@@ -1,0 +1,15 @@
+package org.zalando.fahrschein.http.jdk11;
+
+import org.zalando.fahrschein.http.AbstractRequestFactoryTest;
+import org.zalando.fahrschein.http.api.ContentEncoding;
+import org.zalando.fahrschein.http.api.RequestFactory;
+
+import java.net.http.HttpClient;
+import java.time.Duration;
+
+public class JavaNetNakadiClientTest extends AbstractRequestFactoryTest {
+    @Override
+    protected RequestFactory getRequestFactory() {
+        return new JavaNetRequestFactory(HttpClient.newBuilder().build(), rb -> rb.timeout(Duration.ofSeconds(1)), ContentEncoding.GZIP);
+    }
+}

--- a/fahrschein-e2e-test/src/test/java/org/zalando/fahrschein/http/jdk11/JavaNetNakadiClientTest.java
+++ b/fahrschein-e2e-test/src/test/java/org/zalando/fahrschein/http/jdk11/JavaNetNakadiClientTest.java
@@ -10,6 +10,6 @@ import java.time.Duration;
 public class JavaNetNakadiClientTest extends AbstractRequestFactoryTest {
     @Override
     protected RequestFactory getRequestFactory() {
-        return new JavaNetRequestFactory(HttpClient.newBuilder().build(), rb -> rb.timeout(Duration.ofSeconds(1)), ContentEncoding.GZIP);
+        return new JavaNetRequestFactory(HttpClient.newBuilder().build(), Duration.ofSeconds(1), ContentEncoding.GZIP);
     }
 }

--- a/fahrschein-e2e-test/src/test/java/org/zalando/fahrschein/http/jdk11/JavaNetNakadiClientTest.java
+++ b/fahrschein-e2e-test/src/test/java/org/zalando/fahrschein/http/jdk11/JavaNetNakadiClientTest.java
@@ -6,10 +6,11 @@ import org.zalando.fahrschein.http.api.RequestFactory;
 
 import java.net.http.HttpClient;
 import java.time.Duration;
+import java.util.Optional;
 
 public class JavaNetNakadiClientTest extends AbstractRequestFactoryTest {
     @Override
     protected RequestFactory getRequestFactory() {
-        return new JavaNetRequestFactory(HttpClient.newBuilder().build(), Duration.ofSeconds(1), ContentEncoding.GZIP);
+        return new JavaNetRequestFactory(HttpClient.newBuilder().build(), Optional.of(Duration.ofSeconds(1)), ContentEncoding.GZIP);
     }
 }

--- a/fahrschein-http-api/src/main/java/org/zalando/fahrschein/http/api/Response.java
+++ b/fahrschein-http-api/src/main/java/org/zalando/fahrschein/http/api/Response.java
@@ -8,6 +8,10 @@ public interface Response extends Closeable {
 
     int getStatusCode() throws IOException;
 
+    /**
+     * deprecated because with HTTP/2 we will not get any status text anymore.
+     */
+    @Deprecated
     String getStatusText() throws IOException;
 
     Headers getHeaders();

--- a/fahrschein-http-jdk11/pom.xml
+++ b/fahrschein-http-jdk11/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.zalando</groupId>
         <artifactId>fahrschein-parent</artifactId>
-        <version>0.20.0-SNAPSHOT</version>
+        <version>0.21.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/fahrschein-http-jdk11/pom.xml
+++ b/fahrschein-http-jdk11/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>11</source>
+                    <target>11</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <parent>
+        <groupId>org.zalando</groupId>
+        <artifactId>fahrschein-parent</artifactId>
+        <version>0.20.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>fahrschein-http-jdk11</artifactId>
+    <name>Fahrschein HTTP Client using JDK11's HttpClient</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.zalando</groupId>
+            <artifactId>fahrschein-http-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${version.junit}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${version.mockito}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/fahrschein-http-jdk11/src/main/java/org/zalando/fahrschein/http/jdk11/HttpRequestBuilderAdapter.java
+++ b/fahrschein-http-jdk11/src/main/java/org/zalando/fahrschein/http/jdk11/HttpRequestBuilderAdapter.java
@@ -1,0 +1,7 @@
+package org.zalando.fahrschein.http.jdk11;
+
+import java.net.http.HttpRequest;
+import java.util.function.Function;
+
+public interface HttpRequestBuilderAdapter extends Function<HttpRequest.Builder, HttpRequest.Builder> {
+}

--- a/fahrschein-http-jdk11/src/main/java/org/zalando/fahrschein/http/jdk11/HttpRequestBuilderAdapter.java
+++ b/fahrschein-http-jdk11/src/main/java/org/zalando/fahrschein/http/jdk11/HttpRequestBuilderAdapter.java
@@ -1,7 +1,0 @@
-package org.zalando.fahrschein.http.jdk11;
-
-import java.net.http.HttpRequest;
-import java.util.function.Function;
-
-public interface HttpRequestBuilderAdapter extends Function<HttpRequest.Builder, HttpRequest.Builder> {
-}

--- a/fahrschein-http-jdk11/src/main/java/org/zalando/fahrschein/http/jdk11/JavaNetBufferingRequest.java
+++ b/fahrschein-http-jdk11/src/main/java/org/zalando/fahrschein/http/jdk11/JavaNetBufferingRequest.java
@@ -1,0 +1,141 @@
+package org.zalando.fahrschein.http.jdk11;
+
+import org.zalando.fahrschein.http.api.ContentEncoding;
+import org.zalando.fahrschein.http.api.ContentType;
+import org.zalando.fahrschein.http.api.Headers;
+import org.zalando.fahrschein.http.api.Request;
+import org.zalando.fahrschein.http.api.Response;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.zip.GZIPOutputStream;
+
+final class JavaNetBufferingRequest implements Request {
+
+    private final HttpRequest.Builder request;
+    private final HttpClient client;
+    private final URI uri;
+    private final String method;
+    private final HttpRequestBuilderAdapter adapter;
+    private final ContentEncoding contentEncoding;
+    private boolean executed;
+    private ByteArrayOutputStream bufferedOutput;
+
+    private static final List<String> writeMethods = Arrays.asList("POST", "PATCH", "PUT");
+
+    JavaNetBufferingRequest(URI uri, String method, HttpClient client, HttpRequestBuilderAdapter adapter, ContentEncoding contentEncoding) {
+        this.uri = uri;
+        this.method = method;
+        this.request = HttpRequest.newBuilder().header("Accept-Encoding", "gzip");
+        this.adapter = adapter;
+        this.client = client;
+        this.contentEncoding = contentEncoding;
+    }
+
+    @Override
+    public String getMethod() {
+        return method;
+    }
+
+    @Override
+    public URI getURI() {
+        return uri;
+    }
+
+    @Override
+    public Headers getHeaders() {
+        return new Headers() {
+            @Override
+            public List<String> get(String headerName) {
+                return List.of();
+            }
+
+            @Override
+            public void add(String headerName, String value) {
+                request.header(headerName, value);
+            }
+
+            @Override
+            public void put(String headerName, String value) {
+                request.header(headerName, value);
+            }
+
+            @Override
+            public String getFirst(String headerName) {
+                return "";
+            }
+
+            @Override
+            public Set<String> headerNames() {
+                return Set.of();
+            }
+
+            @Override
+            public long getContentLength() {
+                return 0;
+            }
+
+            @Override
+            public void setContentLength(long contentLength) {
+                // NO-OP.
+            }
+
+            @Override
+            public ContentType getContentType() {
+                return ContentType.APPLICATION_JSON;
+            }
+
+            @Override
+            public void setContentType(ContentType contentType) {
+                request.header("Content-Type", contentType.getValue());
+            }
+        };
+    }
+
+    @Override
+    public OutputStream getBody() throws IOException {
+        if (this.bufferedOutput == null) {
+            this.bufferedOutput = new ByteArrayOutputStream(1024);
+            if (writeMethods.contains(getMethod()) && ContentEncoding.GZIP.equals(this.contentEncoding)) {
+                request.setHeader("Content-Encoding", this.contentEncoding.value());
+                return new GZIPOutputStream(this.bufferedOutput);
+            }
+        }
+        return this.bufferedOutput;
+    }
+
+    @Override
+    public Response execute() throws IOException {
+        try {
+            HttpResponse<InputStream> response = client.send(
+                    adapter.apply(request
+                            .uri(this.uri)
+                            .method(this.method,
+                                    this.bufferedOutput == null
+                                            ? HttpRequest.BodyPublishers.noBody()
+                                            : HttpRequest.BodyPublishers.ofByteArray(this.bufferedOutput.toByteArray()))
+                    )
+                            .build(),
+                    HttpResponse.BodyHandlers.ofInputStream());
+            this.executed = true;
+            return new JavaNetResponse(response);
+        } catch (InterruptedException e) {
+            throw new IOException(e);
+        }
+    }
+
+    private void assertNotExecuted() {
+        if (this.executed) {
+            throw new IllegalStateException("Request already executed");
+        }
+    }
+}

--- a/fahrschein-http-jdk11/src/main/java/org/zalando/fahrschein/http/jdk11/JavaNetRequestFactory.java
+++ b/fahrschein-http-jdk11/src/main/java/org/zalando/fahrschein/http/jdk11/JavaNetRequestFactory.java
@@ -4,25 +4,30 @@ import org.zalando.fahrschein.http.api.ContentEncoding;
 import org.zalando.fahrschein.http.api.Request;
 import org.zalando.fahrschein.http.api.RequestFactory;
 
-import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
+import java.time.Duration;
 
 public final class JavaNetRequestFactory implements RequestFactory {
 
     private final HttpClient client;
-    private final HttpRequestBuilderAdapter adapter;
+    private final Duration timeout;
     private final ContentEncoding contentEncoding;
 
-    public JavaNetRequestFactory(HttpClient client, HttpRequestBuilderAdapter adapter, ContentEncoding contentEncoding) {
+    /**
+     * @param client the HTTP client
+     * @param timeout the timeout duration. See {@code java.net.http.HttpRequest.Builder#timeout}
+     * @param contentEncoding the encoding for publishing events
+     */
+    public JavaNetRequestFactory(HttpClient client, Duration timeout, ContentEncoding contentEncoding) {
         this.client = client;
-        this.adapter = adapter;
+        this.timeout = timeout;
         this.contentEncoding = contentEncoding;
     }
 
     @Override
-    public Request createRequest(URI uri, String method) throws IOException {
-        return new JavaNetBufferingRequest(uri, method, client, adapter, contentEncoding);
+    public Request createRequest(URI uri, String method) {
+        return new JavaNetBufferingRequest(uri, method, client, timeout, contentEncoding);
     }
 
 }

--- a/fahrschein-http-jdk11/src/main/java/org/zalando/fahrschein/http/jdk11/JavaNetRequestFactory.java
+++ b/fahrschein-http-jdk11/src/main/java/org/zalando/fahrschein/http/jdk11/JavaNetRequestFactory.java
@@ -7,27 +7,28 @@ import org.zalando.fahrschein.http.api.RequestFactory;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.time.Duration;
+import java.util.Optional;
 
 public final class JavaNetRequestFactory implements RequestFactory {
 
     private final HttpClient client;
-    private final Duration timeout;
+    private final Optional<Duration> requestTimeout;
     private final ContentEncoding contentEncoding;
 
     /**
      * @param client the HTTP client
-     * @param timeout the timeout duration. See {@code java.net.http.HttpRequest.Builder#timeout}
+     * @param requestTimeout (optional) the request timeout duration. See {@code java.net.http.HttpRequest.Builder#timeout}.
      * @param contentEncoding the encoding for publishing events
      */
-    public JavaNetRequestFactory(HttpClient client, Duration timeout, ContentEncoding contentEncoding) {
+    public JavaNetRequestFactory(HttpClient client, Optional<Duration> requestTimeout, ContentEncoding contentEncoding) {
         this.client = client;
-        this.timeout = timeout;
+        this.requestTimeout = requestTimeout;
         this.contentEncoding = contentEncoding;
     }
 
     @Override
     public Request createRequest(URI uri, String method) {
-        return new JavaNetBufferingRequest(uri, method, client, timeout, contentEncoding);
+        return new JavaNetBufferingRequest(uri, method, client, requestTimeout, contentEncoding);
     }
 
 }

--- a/fahrschein-http-jdk11/src/main/java/org/zalando/fahrschein/http/jdk11/JavaNetRequestFactory.java
+++ b/fahrschein-http-jdk11/src/main/java/org/zalando/fahrschein/http/jdk11/JavaNetRequestFactory.java
@@ -1,0 +1,28 @@
+package org.zalando.fahrschein.http.jdk11;
+
+import org.zalando.fahrschein.http.api.ContentEncoding;
+import org.zalando.fahrschein.http.api.Request;
+import org.zalando.fahrschein.http.api.RequestFactory;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+
+public final class JavaNetRequestFactory implements RequestFactory {
+
+    private final HttpClient client;
+    private final HttpRequestBuilderAdapter adapter;
+    private final ContentEncoding contentEncoding;
+
+    public JavaNetRequestFactory(HttpClient client, HttpRequestBuilderAdapter adapter, ContentEncoding contentEncoding) {
+        this.client = client;
+        this.adapter = adapter;
+        this.contentEncoding = contentEncoding;
+    }
+
+    @Override
+    public Request createRequest(URI uri, String method) throws IOException {
+        return new JavaNetBufferingRequest(uri, method, client, adapter, contentEncoding);
+    }
+
+}

--- a/fahrschein-http-jdk11/src/main/java/org/zalando/fahrschein/http/jdk11/JavaNetResponse.java
+++ b/fahrschein-http-jdk11/src/main/java/org/zalando/fahrschein/http/jdk11/JavaNetResponse.java
@@ -1,0 +1,105 @@
+package org.zalando.fahrschein.http.jdk11;
+
+import org.zalando.fahrschein.http.api.Headers;
+import org.zalando.fahrschein.http.api.HeadersImpl;
+import org.zalando.fahrschein.http.api.Response;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.http.HttpResponse;
+import java.util.zip.GZIPInputStream;
+
+final class JavaNetResponse implements Response {
+
+    private final HttpResponse<InputStream> r;
+
+    JavaNetResponse(HttpResponse<InputStream> r) {
+        this.r = r;
+    }
+
+    @Override
+    public int getStatusCode() throws IOException {
+        return this.r.statusCode();
+    }
+
+    @Override
+    public String getStatusText() throws IOException {
+        switch(this.r.statusCode()) {
+            case (200): return "OK";
+            case (201): return "Created";
+            case (202): return "Accepted";
+            case (203): return "Non Authoritative Information";
+            case (204): return "No Content";
+            case (205): return "Reset Content";
+            case (206): return "Partial Content";
+            case (207): return "Partial Update OK";
+            case (300): return "Mutliple Choices";
+            case (301): return "Moved Permanently";
+            case (302): return "Moved Temporarily";
+            case (303): return "See Other";
+            case (304): return "Not Modified";
+            case (305): return "Use Proxy";
+            case (307): return "Temporary Redirect";
+            case (400): return "Bad Request";
+            case (401): return "Unauthorized";
+            case (402): return "Payment Required";
+            case (403): return "Forbidden";
+            case (404): return "Not Found";
+            case (405): return "Method Not Allowed";
+            case (406): return "Not Acceptable";
+            case (407): return "Proxy Authentication Required";
+            case (408): return "Request Timeout";
+            case (409): return "Conflict";
+            case (410): return "Gone";
+            case (411): return "Length Required";
+            case (412): return "Precondition Failed";
+            case (413): return "Request Entity Too Large";
+            case (414): return "Request-URI Too Long";
+            case (415): return "Unsupported Media Type";
+            case (416): return "Requested Range Not Satisfiable";
+            case (417): return "Expectation Failed";
+            case (418): return "Reauthentication Required";
+            case (419): return "Proxy Reauthentication Required";
+            case (422): return "Unprocessable Entity";
+            case (423): return "Locked";
+            case (424): return "Failed Dependency";
+            case (500): return "Server Error";
+            case (501): return "Not Implemented";
+            case (502): return "Bad Gateway";
+            case (503): return "Service Unavailable";
+            case (504): return "Gateway Timeout";
+            case (505): return "HTTP Version Not Supported";
+            case (507): return "Insufficient Storage";
+            default: return "";
+        }
+    }
+
+    @Override
+    public Headers getHeaders() {
+        Headers h = new HeadersImpl();
+        this.r.headers().map().forEach((k, vs) -> {
+            vs.stream().forEach(v -> {
+                h.add(k, v);
+            });
+        });
+        return h;
+    }
+
+    @Override
+    public InputStream getBody() throws IOException {
+        if (this.getHeaders().get("Content-Encoding").contains("gzip")) {
+            return new GZIPInputStream(r.body());
+        }
+        return r.body();
+    }
+
+    @Override
+    public void close() {
+        try {
+            r.body().close();
+        } catch (Exception e) {
+            // ignore
+        }
+    }
+
+}

--- a/fahrschein-http-jdk11/src/test/java/org/zalando/fahrschein/http/jdk11/JavaNetRequestFactoryTest.java
+++ b/fahrschein-http-jdk11/src/test/java/org/zalando/fahrschein/http/jdk11/JavaNetRequestFactoryTest.java
@@ -1,0 +1,244 @@
+package org.zalando.fahrschein.http.jdk11;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.zalando.fahrschein.http.api.ContentEncoding;
+import org.zalando.fahrschein.http.api.ContentType;
+import org.zalando.fahrschein.http.api.Request;
+import org.zalando.fahrschein.http.api.RequestFactory;
+import org.zalando.fahrschein.http.api.Response;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.SocketTimeoutException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(MockitoJUnitRunner.class)
+public class JavaNetRequestFactoryTest {
+
+    static HttpServer server;
+    static URI serverAddress;
+
+    @BeforeClass
+    public static void startServer() throws IOException {
+        server = HttpServer.create(new InetSocketAddress("localhost", 0), 1);
+        serverAddress = URI.create("http://localhost:" + server.getAddress().getPort());
+        server.setExecutor(Executors.newSingleThreadExecutor());
+        server.start();
+    }
+
+    @Captor
+    public ArgumentCaptor<HttpExchange> exchangeCaptor;
+
+    @Test
+    public void testGetRequest() throws IOException {
+        // given
+        String expectedResponse = "{}";
+        HttpHandler spy = Mockito.spy(new SimpleRequestResponseContentHandler(expectedResponse));
+        server.createContext("/get", spy);
+
+        // when
+        RequestFactory f = getRequestFactory(ContentEncoding.IDENTITY);
+        Request r = f.createRequest(serverAddress.resolve("/get"), "GET");
+        Response executed = r.execute();
+        String actualResponse = readStream(executed.getBody());
+
+        // then
+        assertEquals(serverAddress.resolve("/get"), r.getURI());
+        Mockito.verify(spy).handle(exchangeCaptor.capture());
+        HttpExchange capturedArgument = exchangeCaptor.<HttpExchange> getValue();
+        assertEquals("GET", capturedArgument.getRequestMethod());
+        assertEquals(200, executed.getStatusCode());
+        assertEquals("OK", executed.getStatusText());
+        assertEquals(expectedResponse, actualResponse);
+    }
+
+    @Test
+    public void testPostRequest() throws IOException {
+        // given
+        String requestBody = "{}";
+        String responseBody = "{}";
+        SimpleRequestResponseContentHandler spy = Mockito.spy(new SimpleRequestResponseContentHandler(responseBody));
+        server.createContext("/post", spy);
+
+        // when
+        RequestFactory f = getRequestFactory(ContentEncoding.IDENTITY);
+        Request r = f.createRequest(serverAddress.resolve("/post"), "POST");
+        r.getHeaders().setContentType(ContentType.APPLICATION_JSON);
+        try (final OutputStream body = r.getBody()) {
+            body.write(requestBody.getBytes());
+        }
+        Response executed = r.execute();
+        String actualResponse = readStream(executed.getBody());
+
+        // then
+        Mockito.verify(spy).handle(exchangeCaptor.capture());
+        HttpExchange capturedArgument = exchangeCaptor.getValue();
+        assertEquals("POST", capturedArgument.getRequestMethod());
+        assertThat("no content-encoding header", capturedArgument.getRequestHeaders().get("content-encoding"), nullValue());
+        assertEquals(URI.create("/post"), capturedArgument.getRequestURI());
+        assertEquals(requestBody, spy.getRequestBody());
+        assertEquals(responseBody, actualResponse);
+    }
+
+    @Test
+    public void testGzippedResponseBody() throws IOException {
+        // given
+        String expectedResponse = "{}";
+        HttpHandler spy = Mockito.spy(new GzippedResponseContentHandler(expectedResponse));
+        server.createContext("/gzipped", spy);
+
+        // when
+        RequestFactory f = getRequestFactory(ContentEncoding.IDENTITY);
+        Request r = f.createRequest(serverAddress.resolve("/gzipped"), "GET");
+        Response executed = r.execute();
+        String actualResponse = readStream(executed.getBody());
+
+        // then
+        Mockito.verify(spy).handle(exchangeCaptor.capture());
+        HttpExchange capturedArgument = exchangeCaptor.getValue();
+        assertThat("accept-encoding header", capturedArgument.getRequestHeaders().get("accept-encoding"), equalTo(Arrays.asList("gzip")));
+        assertThat("no content-encoding header", capturedArgument.getRequestHeaders().get("content-encoding"), nullValue());
+        assertEquals(URI.create("/gzipped"), capturedArgument.getRequestURI());
+        assertEquals(expectedResponse, actualResponse);
+    }
+
+    @Test(expected = java.net.http.HttpTimeoutException.class)
+    public void testTimeout() throws IOException {
+        // given
+        server.createContext("/timeout", exchange -> {
+            try {
+                Thread.sleep(10l);
+                exchange.sendResponseHeaders(201, 0);
+            } catch (InterruptedException e) { }
+        });
+
+        // when
+        RequestFactory f = new JavaNetRequestFactory(HttpClient.newBuilder().build(),
+                rb -> rb.timeout(Duration.ofMillis(1)), ContentEncoding.IDENTITY);
+        Request r = f.createRequest(serverAddress.resolve("/timeout"), "GET");
+        r.execute();
+    }
+
+    @Test
+    public void testGzippedRequestBody() throws IOException {
+        // given
+        String requestBody = "{}";
+        String responseBody = "{}";
+        SimpleRequestResponseContentHandler spy = Mockito.spy(new SimpleRequestResponseContentHandler(responseBody));
+        server.createContext("/gzipped-post", spy);
+
+        // when
+        RequestFactory f = getRequestFactory(ContentEncoding.GZIP);
+        Request r = f.createRequest(serverAddress.resolve("/gzipped-post"), "POST");
+        r.getHeaders().setContentType(ContentType.APPLICATION_JSON);
+        try (final OutputStream body = r.getBody()) {
+            body.write("{}".getBytes());
+        }
+        Response executed = r.execute();
+        String actualResponse = readStream(executed.getBody());
+
+        // then
+        Mockito.verify(spy).handle(exchangeCaptor.capture());
+        HttpExchange capturedArgument = exchangeCaptor.getValue();
+        assertEquals("POST", capturedArgument.getRequestMethod());
+        assertEquals(URI.create("/gzipped-post"), capturedArgument.getRequestURI());
+        assertThat("content-encoding header", capturedArgument.getRequestHeaders().get("content-encoding"), equalTo(Arrays.asList("gzip")));
+        assertEquals(requestBody, spy.getRequestBody());
+        assertEquals(responseBody, actualResponse);
+    }
+
+    private RequestFactory getRequestFactory(ContentEncoding contentEncoding) {
+        return new JavaNetRequestFactory(HttpClient.newHttpClient(), rb -> rb.timeout(Duration.ofSeconds(1)), contentEncoding);
+    }
+
+    static String readStream(InputStream stream) throws IOException {
+        String res = new BufferedReader(
+                new InputStreamReader(stream, UTF_8))
+                .lines()
+                .collect(Collectors.joining("\n"));
+        stream.close();
+        return res;
+    }
+
+    private static class SimpleRequestResponseContentHandler implements HttpHandler {
+
+        private String requestBody;
+        private final String responseBody;
+
+        SimpleRequestResponseContentHandler(String responseBody) {
+            this.responseBody = responseBody;
+        }
+
+        public String getRequestBody() {
+            return requestBody;
+        }
+
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+
+            if (exchange.getRequestHeaders().containsKey("Content-Encoding") && exchange.getRequestHeaders().get("Content-Encoding").contains("gzip")) {
+                requestBody = readStream(new GZIPInputStream(exchange.getRequestBody()));
+            } else {
+                requestBody = readStream(exchange.getRequestBody());
+            }
+
+            byte[] bytes = responseBody.getBytes(UTF_8);
+            exchange.sendResponseHeaders(200, bytes.length);
+            OutputStream responseBody = exchange.getResponseBody();
+            responseBody.write(bytes);
+            responseBody.flush();
+            responseBody.close();
+        }
+    }
+
+    private static class GzippedResponseContentHandler implements HttpHandler {
+
+        private final byte[] rawResponse;
+
+        GzippedResponseContentHandler(String response) throws IOException {
+            byte[] stringResponse = response.getBytes(UTF_8);
+            ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
+            GZIPOutputStream zipStream = new GZIPOutputStream(byteStream);
+            zipStream.write(stringResponse);
+            zipStream.close();
+            this.rawResponse = byteStream.toByteArray();
+        }
+
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            exchange.getResponseHeaders().set("Content-Encoding", "gzip");
+            exchange.sendResponseHeaders(200, rawResponse.length);
+            OutputStream responseBody = exchange.getResponseBody();
+            responseBody.write(rawResponse);
+            responseBody.close();
+        }
+    }
+
+}

--- a/fahrschein-http-jdk11/src/test/java/org/zalando/fahrschein/http/jdk11/JavaNetRequestFactoryTest.java
+++ b/fahrschein-http-jdk11/src/test/java/org/zalando/fahrschein/http/jdk11/JavaNetRequestFactoryTest.java
@@ -23,7 +23,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
-import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.time.Duration;
@@ -140,8 +139,7 @@ public class JavaNetRequestFactoryTest {
         });
 
         // when
-        RequestFactory f = new JavaNetRequestFactory(HttpClient.newBuilder().build(),
-                rb -> rb.timeout(Duration.ofMillis(1)), ContentEncoding.IDENTITY);
+        RequestFactory f = new JavaNetRequestFactory(HttpClient.newBuilder().build(), Duration.ofMillis(1), ContentEncoding.IDENTITY);
         Request r = f.createRequest(serverAddress.resolve("/timeout"), "GET");
         r.execute();
     }
@@ -175,7 +173,7 @@ public class JavaNetRequestFactoryTest {
     }
 
     private RequestFactory getRequestFactory(ContentEncoding contentEncoding) {
-        return new JavaNetRequestFactory(HttpClient.newHttpClient(), rb -> rb.timeout(Duration.ofSeconds(1)), contentEncoding);
+        return new JavaNetRequestFactory(HttpClient.newHttpClient(), Duration.ofSeconds(1), contentEncoding);
     }
 
     static String readStream(InputStream stream) throws IOException {

--- a/fahrschein-http-jdk11/src/test/java/org/zalando/fahrschein/http/jdk11/JavaNetRequestFactoryTest.java
+++ b/fahrschein-http-jdk11/src/test/java/org/zalando/fahrschein/http/jdk11/JavaNetRequestFactoryTest.java
@@ -27,6 +27,7 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
@@ -139,7 +140,7 @@ public class JavaNetRequestFactoryTest {
         });
 
         // when
-        RequestFactory f = new JavaNetRequestFactory(HttpClient.newBuilder().build(), Duration.ofMillis(1), ContentEncoding.IDENTITY);
+        RequestFactory f = new JavaNetRequestFactory(HttpClient.newBuilder().build(), Optional.of(Duration.ofMillis(1)), ContentEncoding.IDENTITY);
         Request r = f.createRequest(serverAddress.resolve("/timeout"), "GET");
         r.execute();
     }
@@ -173,7 +174,7 @@ public class JavaNetRequestFactoryTest {
     }
 
     private RequestFactory getRequestFactory(ContentEncoding contentEncoding) {
-        return new JavaNetRequestFactory(HttpClient.newHttpClient(), Duration.ofSeconds(1), contentEncoding);
+        return new JavaNetRequestFactory(HttpClient.newHttpClient(), Optional.of(Duration.ofSeconds(1)), contentEncoding);
     }
 
     static String readStream(InputStream stream) throws IOException {

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,7 @@
         <module>fahrschein-typeresolver</module>
         <module>fahrschein-http-api</module>
         <module>fahrschein-http-simple</module>
+        <module>fahrschein-http-jdk11</module>
         <module>fahrschein-http-apache</module>
         <module>fahrschein-http-spring</module>
         <module>fahrschein-e2e-test</module>


### PR DESCRIPTION
A new zero-dependency RequestFactory implementation, based on the [java.net HttpClient](https://openjdk.java.net/groups/net/httpclient/intro.html) coming with JDK11+.

Work Packages:
* [x] API design & impl
* [x] README doc
* [x] E2E-Test
* [x] GZip support

Open Questions:
1. Do we want to make this a drop-in replacement for the old http-simple?
2. Should we mark this API as "experimental" in the first release? If so, how?
3. Do we offer this module before switching the general Fahrschein baseline to JDK11?
4. There will be conflicts with https://github.com/zalando-nakadi/fahrschein/pull/311 - which to merge first, and which to rebase?
