### PR TITLE
Cleanup deprecation warnings in tests

### DIFF
--- a/fahrschein/src/test/java/org/zalando/fahrschein/MockServer.java
+++ b/fahrschein/src/test/java/org/zalando/fahrschein/MockServer.java
@@ -22,9 +22,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/fahrschein/src/test/java/org/zalando/fahrschein/NakadiClientTest.java
+++ b/fahrschein/src/test/java/org/zalando/fahrschein/NakadiClientTest.java
@@ -17,13 +17,13 @@ import java.util.List;
 import java.util.Set;
 
 import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 import static org.zalando.fahrschein.AuthorizationBuilder.authorization;
-import static org.zalando.fahrschein.domain.Authorization.AuthorizationAttribute.ANYONE;
 
 public class NakadiClientTest {
     public static class SomeEvent {

--- a/fahrschein/src/test/java/org/zalando/fahrschein/NakadiReaderDeserializationTest.java
+++ b/fahrschein/src/test/java/org/zalando/fahrschein/NakadiReaderDeserializationTest.java
@@ -28,8 +28,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/fahrschein/src/test/java/org/zalando/fahrschein/StreamParametersTest.java
+++ b/fahrschein/src/test/java/org/zalando/fahrschein/StreamParametersTest.java
@@ -4,9 +4,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.hamcrest.collection.IsArrayWithSize.arrayWithSize;
-import static org.junit.Assert.assertThat;
 
 public class StreamParametersTest {
 


### PR DESCRIPTION
Deprecations removal:

* <T>assertThat(T,org.hamcrest.Matcher<? super T>) in org.junit.Assert has been deprecated
