### PR TITLE
Adds ZStandard compression support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
  - Support for both high-level (subscription) and low-level APIs
  - Pluggable HTTP client implementations
  - Gzip encoding support for publishing and consuming events
+ - ZStandard compression support for publishing events
 
 ## Installation
 
@@ -272,9 +273,9 @@ RequestFactory into a `IdentityAcceptEncodingRequestFactory`, which sets the `Ac
 
 ### Publishing
 
-For event publishing, the `Request` body can also get gzip-encoded by Fahrschein, if enabled when building the RequestFactory.
-For this, you need to pass `ContentEncoding.GZIP`, or if compression is undesired, pass `ContentEncoding.IDENTITY`.
-In the future, we may support other encoding formats, like Zstandard.
+For event publishing, the `Request` body can also get compressed by Fahrschein, if enabled when building the RequestFactory.
+For this, you need to pass either `ContentEncoding.GZIP`, `ContentEncoding.ZSTD`, or if compression is undesired, pass `ContentEncoding.IDENTITY`.
+Zstandard compression was added in version `0.21.0`.
 
 ## Fahrschein compared to other Nakadi client libraries
 

--- a/fahrschein-http-api/pom.xml
+++ b/fahrschein-http-api/pom.xml
@@ -16,6 +16,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.github.luben</groupId>
+            <artifactId>zstd-jni</artifactId>
+            <version>1.5.2-2</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
             <version>2.0.1</version>

--- a/fahrschein-http-api/src/main/java/org/zalando/fahrschein/http/api/ContentEncoding.java
+++ b/fahrschein-http-api/src/main/java/org/zalando/fahrschein/http/api/ContentEncoding.java
@@ -1,7 +1,16 @@
 package org.zalando.fahrschein.http.api;
 
+import com.github.luben.zstd.ZstdOutputStream;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.zip.GZIPOutputStream;
+
 public enum ContentEncoding {
-    IDENTITY("identity"), GZIP("gzip");
+    IDENTITY("identity"), GZIP("gzip"), ZSTD("zstd");
 
     private final String value;
 
@@ -9,7 +18,25 @@ public enum ContentEncoding {
         this.value = value;
     }
 
+    private static final Set<String> HTTP_METHODS_WITH_COMPRESSION_SUPPORT = new HashSet<>(Arrays.asList("POST"));
+
+    public boolean isSupported(String httpMethod) {
+        return HTTP_METHODS_WITH_COMPRESSION_SUPPORT.contains(httpMethod);
+    }
+
     public String value() {
         return value;
+    }
+
+    public OutputStream wrap(OutputStream out) throws IOException {
+        switch (this) {
+            case GZIP:
+                return new GZIPOutputStream(out);
+            case ZSTD:
+                return new ZstdOutputStream(out);
+            default:
+                return out;
+        }
+
     }
 }

--- a/fahrschein-http-api/src/main/java/org/zalando/fahrschein/http/api/ContentEncoding.java
+++ b/fahrschein-http-api/src/main/java/org/zalando/fahrschein/http/api/ContentEncoding.java
@@ -34,8 +34,10 @@ public enum ContentEncoding {
                 return new GZIPOutputStream(out);
             case ZSTD:
                 return new ZstdOutputStream(out);
-            default:
+            case IDENTITY:
                 return out;
+            default:
+                throw new UnsupportedOperationException(String.format("No output stream-wrapping defined for ContentEncoding: %s", out));
         }
 
     }

--- a/fahrschein-http-api/src/main/java/org/zalando/fahrschein/http/api/Headers.java
+++ b/fahrschein-http-api/src/main/java/org/zalando/fahrschein/http/api/Headers.java
@@ -9,8 +9,8 @@ public interface Headers {
     String AUTHORIZATION = "Authorization";
     String CONTENT_LENGTH = "Content-Length";
     String CONTENT_TYPE = "Content-Type";
-    String COOKIE = "Cookie";
-
+    String CONTENT_ENCODING = "Content-Encoding";
+    String ACCEPT_ENCODING = "Accept-Encoding";
 
     List<String> get(String headerName);
 

--- a/fahrschein-http-jdk11/src/main/java/org/zalando/fahrschein/http/jdk11/JavaNetBufferingRequest.java
+++ b/fahrschein-http-jdk11/src/main/java/org/zalando/fahrschein/http/jdk11/JavaNetBufferingRequest.java
@@ -34,7 +34,7 @@ final class JavaNetBufferingRequest implements Request {
     JavaNetBufferingRequest(URI uri, String method, HttpClient client, Optional<Duration> requestTimeout, ContentEncoding contentEncoding) {
         this.uri = uri;
         this.method = method;
-        this.request = HttpRequest.newBuilder().header("Accept-Encoding", "gzip");
+        this.request = HttpRequest.newBuilder().header(Headers.ACCEPT_ENCODING, "gzip");
         this.client = client;
         this.requestTimeout = requestTimeout;
         this.contentEncoding = contentEncoding;
@@ -95,7 +95,7 @@ final class JavaNetBufferingRequest implements Request {
 
             @Override
             public void setContentType(ContentType contentType) {
-                request.header("Content-Type", contentType.getValue());
+                request.header(Headers.CONTENT_TYPE, contentType.getValue());
             }
         };
     }
@@ -107,7 +107,7 @@ final class JavaNetBufferingRequest implements Request {
             // probably premature optimization, but we're omitting the unnecessary
             // "Content-Encoding: identity" header
             if (ContentEncoding.IDENTITY != this.contentEncoding) {
-                request.setHeader("Content-Encoding", this.contentEncoding.value());
+                request.setHeader(Headers.CONTENT_ENCODING, this.contentEncoding.value());
             }
             return this.contentEncoding.wrap(this.bufferedOutput);
         }

--- a/fahrschein-http-jdk11/src/main/java/org/zalando/fahrschein/http/jdk11/JavaNetResponse.java
+++ b/fahrschein-http-jdk11/src/main/java/org/zalando/fahrschein/http/jdk11/JavaNetResponse.java
@@ -87,7 +87,7 @@ final class JavaNetResponse implements Response {
 
     @Override
     public InputStream getBody() throws IOException {
-        if (this.getHeaders().get("Content-Encoding").contains("gzip")) {
+        if (this.getHeaders().get(Headers.CONTENT_ENCODING).contains("gzip")) {
             return new GZIPInputStream(r.body());
         }
         return r.body();

--- a/fahrschein-http-simple/src/main/java/org/zalando/fahrschein/http/simple/SimpleBufferingRequest.java
+++ b/fahrschein-http-simple/src/main/java/org/zalando/fahrschein/http/simple/SimpleBufferingRequest.java
@@ -74,8 +74,8 @@ final class SimpleBufferingRequest implements Request {
         }
 
         // allow gzip-compression from server response
-        if (connection.getRequestProperty("Accept-Encoding") == null) {
-            connection.setRequestProperty("Accept-Encoding", "gzip");
+        if (connection.getRequestProperty(Headers.ACCEPT_ENCODING) == null) {
+            connection.setRequestProperty(Headers.ACCEPT_ENCODING, "gzip");
         }
 
         if (this.connection.getDoOutput()) {
@@ -112,7 +112,7 @@ final class SimpleBufferingRequest implements Request {
                 // probably premature optimization, but we're omitting the unnecessary
                 // "Content-Encoding: identity" header
                 if (ContentEncoding.IDENTITY != this.contentEncoding) {
-                    this.connection.setRequestProperty("Content-Encoding", this.contentEncoding.value());
+                    this.connection.setRequestProperty(Headers.CONTENT_ENCODING, this.contentEncoding.value());
                 }
                 return this.contentEncoding.wrap(this.bufferedOutput);
             }

--- a/fahrschein-http-simple/src/main/java/org/zalando/fahrschein/http/simple/SimpleBufferingRequest.java
+++ b/fahrschein-http-simple/src/main/java/org/zalando/fahrschein/http/simple/SimpleBufferingRequest.java
@@ -108,9 +108,13 @@ final class SimpleBufferingRequest implements Request {
         assertNotExecuted();
         if (this.bufferedOutput == null) {
             this.bufferedOutput = new ByteArrayOutputStream(1024);
-            if (this.connection.getDoOutput() && ContentEncoding.GZIP.equals(this.contentEncoding)) {
-                this.connection.setRequestProperty("Content-Encoding", this.contentEncoding.value());
-                return new GZIPOutputStream(this.bufferedOutput);
+            if (this.contentEncoding.isSupported(getMethod())) {
+                // probably premature optimization, but we're omitting the unnecessary
+                // "Content-Encoding: identity" header
+                if (ContentEncoding.IDENTITY != this.contentEncoding) {
+                    this.connection.setRequestProperty("Content-Encoding", this.contentEncoding.value());
+                }
+                return this.contentEncoding.wrap(this.bufferedOutput);
             }
         }
         return this.bufferedOutput;

--- a/fahrschein-http-simple/src/main/java/org/zalando/fahrschein/http/simple/SimpleResponse.java
+++ b/fahrschein-http-simple/src/main/java/org/zalando/fahrschein/http/simple/SimpleResponse.java
@@ -69,7 +69,7 @@ final class SimpleResponse implements Response {
         if (this.responseStream == null) {
             final InputStream errorStream = connection.getErrorStream();
             this.responseStream = (errorStream != null ? errorStream : connection.getInputStream());
-            if (this.getHeaders().get("Content-Encoding").contains("gzip")) {
+            if (this.getHeaders().get(Headers.CONTENT_ENCODING).contains("gzip")) {
                 this.responseStream = new GZIPInputStream(this.responseStream);
             }
         }

--- a/fahrschein-http-test-support/src/main/java/org/zalando/fahrschein/http/test/AbstractRequestFactoryTest.java
+++ b/fahrschein-http-test-support/src/main/java/org/zalando/fahrschein/http/test/AbstractRequestFactoryTest.java
@@ -11,6 +11,7 @@ import org.mockito.Captor;
 import org.mockito.Mockito;
 import org.zalando.fahrschein.http.api.ContentEncoding;
 import org.zalando.fahrschein.http.api.ContentType;
+import org.zalando.fahrschein.http.api.Headers;
 import org.zalando.fahrschein.http.api.Request;
 import org.zalando.fahrschein.http.api.RequestFactory;
 import org.zalando.fahrschein.http.api.Response;
@@ -71,51 +72,29 @@ public abstract class AbstractRequestFactoryTest {
         Mockito.verify(spy).handle(exchangeCaptor.capture());
         HttpExchange capturedArgument = exchangeCaptor.getValue();
         assertThat("accept-encoding header", capturedArgument.getRequestHeaders().getFirst("accept-encoding"), containsString("gzip"));
-        assertThat("no content-encoding header", capturedArgument.getRequestHeaders().get("content-encoding"), nullValue());
+        assertThat("no content-encoding header", capturedArgument.getRequestHeaders().get(Headers.CONTENT_ENCODING), nullValue());
         assertEquals(URI.create("/gzipped"), capturedArgument.getRequestURI());
         assertEquals(expectedResponse, actualResponse);
     }
 
     @Test
-    public void testGzippedRequestBody() throws IOException {
-        // given
-        String requestBody = "{}";
-        String responseBody = "{}";
-        SimpleRequestResponseContentHandler spy = Mockito.spy(new SimpleRequestResponseContentHandler(responseBody));
-        server.createContext("/gzipped-post", spy);
-
-        // when
-        final RequestFactory f = defaultRequestFactory(ContentEncoding.GZIP);
-        Request r = f.createRequest(serverAddress.resolve("/gzipped-post"), "POST");
-        r.getHeaders().setContentType(ContentType.APPLICATION_JSON);
-        try (final OutputStream body = r.getBody()) {
-            body.write(requestBody.getBytes());
+    public void testEncodedRequestBody() throws IOException {
+        for(ContentEncoding encoding : ContentEncoding.values()) {
+            doTestEncodedRequestBody(encoding);
         }
-        Response executed = r.execute();
-        String actualResponse = readStream(executed.getBody());
-
-        // then
-        Mockito.verify(spy).handle(exchangeCaptor.capture());
-        HttpExchange capturedArgument = exchangeCaptor.getValue();
-        assertEquals("POST", capturedArgument.getRequestMethod());
-        assertEquals(URI.create("/gzipped-post"), capturedArgument.getRequestURI());
-        assertThat("content-encoding header", capturedArgument.getRequestHeaders().get("content-encoding"), equalTo(Arrays.asList("gzip")));
-        assertEquals(requestBody, spy.getRequestBody());
-        assertEquals(responseBody, actualResponse);
     }
 
-    @Test
-    public void testZStandardRequestBody() throws IOException {
+    void doTestEncodedRequestBody(ContentEncoding encoding) throws IOException {
         // given
         String requestBody = "{}";
         String responseBody = "{}";
         SimpleRequestResponseContentHandler spy = Mockito.spy(new SimpleRequestResponseContentHandler(responseBody));
-        server.createContext("/zstd-post", spy);
+        String requestPath = "/post-" + encoding.value();
+        server.createContext(requestPath, spy);
 
         // when
-        RequestFactory f = defaultRequestFactory(ContentEncoding.ZSTD);
-
-        Request r = f.createRequest(serverAddress.resolve("/zstd-post"), "POST");
+        final RequestFactory f = defaultRequestFactory(encoding);
+        Request r = f.createRequest(serverAddress.resolve(requestPath), "POST");
         r.getHeaders().setContentType(ContentType.APPLICATION_JSON);
         try (final OutputStream body = r.getBody()) {
             body.write(requestBody.getBytes());
@@ -127,8 +106,12 @@ public abstract class AbstractRequestFactoryTest {
         Mockito.verify(spy).handle(exchangeCaptor.capture());
         HttpExchange capturedArgument = exchangeCaptor.getValue();
         assertEquals("POST", capturedArgument.getRequestMethod());
-        assertEquals(URI.create("/zstd-post"), capturedArgument.getRequestURI());
-        assertThat("content-encoding header", capturedArgument.getRequestHeaders().get("content-encoding"), equalTo(Arrays.asList("zstd")));
+        assertEquals(URI.create(requestPath), capturedArgument.getRequestURI());
+        if (encoding == ContentEncoding.IDENTITY) {
+            assertThat("no content-encoding header", capturedArgument.getRequestHeaders().get(Headers.CONTENT_ENCODING), is(nullValue()));
+        } else {
+            assertThat("content-encoding header", capturedArgument.getRequestHeaders().get(Headers.CONTENT_ENCODING), equalTo(Arrays.asList(encoding.value())));
+        }
         assertEquals(requestBody, spy.getRequestBody());
         assertEquals(responseBody, actualResponse);
     }
@@ -158,9 +141,9 @@ public abstract class AbstractRequestFactoryTest {
         @Override
         public void handle(HttpExchange exchange) throws IOException {
             try {
-                if (exchange.getRequestHeaders().containsKey("Content-Encoding") && exchange.getRequestHeaders().get("Content-Encoding").contains("gzip")) {
+                if (exchange.getRequestHeaders().containsKey(Headers.CONTENT_ENCODING) && exchange.getRequestHeaders().get(Headers.CONTENT_ENCODING).contains("gzip")) {
                     requestBody = readStream(new GZIPInputStream(exchange.getRequestBody()));
-                } else if (exchange.getRequestHeaders().containsKey("Content-Encoding") && exchange.getRequestHeaders().get("Content-Encoding").contains("zstd")) {
+                } else if (exchange.getRequestHeaders().containsKey(Headers.CONTENT_ENCODING) && exchange.getRequestHeaders().get(Headers.CONTENT_ENCODING).contains("zstd")) {
                     requestBody = readStream(new ZstdInputStream(exchange.getRequestBody()));
                 } else {
                     requestBody = readStream(exchange.getRequestBody());
@@ -192,7 +175,7 @@ public abstract class AbstractRequestFactoryTest {
 
         @Override
         public void handle(HttpExchange exchange) throws IOException {
-            exchange.getResponseHeaders().set("Content-Encoding", "gzip");
+            exchange.getResponseHeaders().set(Headers.CONTENT_ENCODING, "gzip");
             exchange.sendResponseHeaders(200, rawResponse.length);
             OutputStream responseBody = exchange.getResponseBody();
             responseBody.write(rawResponse);

--- a/fahrschein/src/main/java/org/zalando/fahrschein/IdentityAcceptEncodingRequestFactory.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/IdentityAcceptEncodingRequestFactory.java
@@ -1,5 +1,6 @@
 package org.zalando.fahrschein;
 
+import org.zalando.fahrschein.http.api.Headers;
 import org.zalando.fahrschein.http.api.Request;
 import org.zalando.fahrschein.http.api.RequestFactory;
 
@@ -17,7 +18,7 @@ public class IdentityAcceptEncodingRequestFactory implements RequestFactory {
     @Override
     public Request createRequest(URI uri, String method) throws IOException {
         Request request = delegate.createRequest(uri, method);
-        request.getHeaders().put("Accept-Encoding", "identity");
+        request.getHeaders().put(Headers.ACCEPT_ENCODING, "identity");
         return request;
     }
 }

--- a/fahrschein/src/test/java/org/zalando/fahrschein/IdentityAcceptEncodingRequestFactoryTest.java
+++ b/fahrschein/src/test/java/org/zalando/fahrschein/IdentityAcceptEncodingRequestFactoryTest.java
@@ -29,20 +29,20 @@ public class IdentityAcceptEncodingRequestFactoryTest {
         IdentityAcceptEncodingRequestFactory SUT = new IdentityAcceptEncodingRequestFactory(delegate);
         SUT.createRequest(URI.create("any://uri"), "GET");
 
-        assertEquals(Arrays.asList("identity"), headers.get("Accept-Encoding"));
+        assertEquals(Arrays.asList("identity"), headers.get(Headers.ACCEPT_ENCODING));
     }
 
     @Test
     public void shouldOverrideExistingAcceptEncodingHeader() throws IOException {
         final Headers headers = new HeadersImpl();
-        headers.put("Accept-Encoding", "gzip");
+        headers.put(Headers.ACCEPT_ENCODING, "gzip");
         when(request.getHeaders()).thenReturn(headers);
         when(delegate.createRequest(any(URI.class), any(String.class))).thenReturn(request);
 
         IdentityAcceptEncodingRequestFactory SUT = new IdentityAcceptEncodingRequestFactory(delegate);
         SUT.createRequest(URI.create("any://uri"), "GET");
 
-        assertEquals(Arrays.asList("identity"), headers.get("Accept-Encoding"));
+        assertEquals(Arrays.asList("identity"), headers.get(Headers.ACCEPT_ENCODING));
     }
 
 }


### PR DESCRIPTION
Adds ZStandard compression support, based on the same library that also Nakadi is using (com.github.luben:zstd-jni).

* Added compression support for both GZip and ZStandard
* Limits compression to `POST` requests, as [Nakadi only supports it for those](https://github.com/zalando/nakadi/blob/master/core-common/src/main/java/org/zalando/nakadi/util/CompressionBodyRequestFilter.java#L52). Luckily Fahrschein does not send any PATCH or PUT anyway. 
* Introduces new Header constants for Content-Encoding and Accept-Encoding.

Closes #310 

## Tasks

* [x] Code implementation & unit tests
* [x] End-to-end test 
* [x] README documentation
