### PR TITLE
Dependency cleanup

### DIFF
--- a/fahrschein-e2e-test/pom.xml
+++ b/fahrschein-e2e-test/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>4.3.1</version>
+            <version>${version.mockito}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/fahrschein-http-apache/pom.xml
+++ b/fahrschein-http-apache/pom.xml
@@ -24,6 +24,23 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>4.5.13</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <version>${version.slf4j}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${version.slf4j}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/fahrschein-jdbc/pom.xml
+++ b/fahrschein-jdbc/pom.xml
@@ -115,7 +115,7 @@
         <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
-            <version>2.4.3</version>
+            <version>5.0.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/fahrschein-redis/pom.xml
+++ b/fahrschein-redis/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-redis</artifactId>
-            <version>1.7.2.RELEASE</version>
+            <version>2.6.3</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
-            <version>2.8.1</version>
+            <version>3.8.0</version>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>

--- a/fahrschein-redis/src/test/java/org/zalando/fahrschein/redis/RedisCursorManagerIT.java
+++ b/fahrschein-redis/src/test/java/org/zalando/fahrschein/redis/RedisCursorManagerIT.java
@@ -2,6 +2,7 @@ package org.zalando.fahrschein.redis;
 
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.zalando.fahrschein.CursorManager;
@@ -26,9 +27,9 @@ public class RedisCursorManagerIT {
     @Test
     public void connectToRedisAndUseCursorManager() throws IOException {
 
-        final JedisConnectionFactory jedisConnectionFactory = new JedisConnectionFactory();
-        jedisConnectionFactory.setUsePool(true);
-        jedisConnectionFactory.setShardInfo(new JedisShardInfo(redis.getHost(), redis.getFirstMappedPort()));
+        final JedisConnectionFactory jedisConnectionFactory = new JedisConnectionFactory(
+                new RedisStandaloneConfiguration(redis.getHost(), redis.getFirstMappedPort()));
+        jedisConnectionFactory.afterPropertiesSet();
         final CursorManager cursorManager = new RedisCursorManager(jedisConnectionFactory, "fahrschein_redis_test");
 
         Collection<Cursor> cursors;

--- a/pom.xml
+++ b/pom.xml
@@ -74,9 +74,9 @@
         <maven.compiler.failOnWarning>true</maven.compiler.failOnWarning>
 
         <version.jackson>2.13.1</version.jackson>
-        <version.spring>5.3.14</version.spring>
+        <version.spring>5.3.18</version.spring>
         <version.slf4j>1.7.25</version.slf4j>
-        <version.mockito>2.28.2</version.mockito>
+        <version.mockito>4.3.1</version.mockito>
         <version.junit>4.13.1</version.junit>
         <version.testcontainers>1.16.2</version.testcontainers>
     </properties>


### PR DESCRIPTION
* Ensures jcl-over-slf4j in all cases
* Aligns and bumps mockito version
* Aligns and bumps HikariCP
* Bumps spring to avoid CVE vulnerability warning
* Bumps redis and spring-data-redis