### PR TITLE
JDK11 client: Avoid copying of headers

### DIFF
--- a/fahrschein-http-jdk11/src/main/java/org/zalando/fahrschein/http/jdk11/JavaNetBufferingRequest.java
+++ b/fahrschein-http-jdk11/src/main/java/org/zalando/fahrschein/http/jdk11/JavaNetBufferingRequest.java
@@ -53,9 +53,12 @@ final class JavaNetBufferingRequest implements Request {
     @Override
     public Headers getHeaders() {
         return new Headers() {
+
+            private static final String HEADER_IMPLEMENTATION_IS_WRITE_ONLY = "Header implementation is write-only";
+
             @Override
             public List<String> get(String headerName) {
-                return List.of();
+                throw new UnsupportedOperationException(HEADER_IMPLEMENTATION_IS_WRITE_ONLY);
             }
 
             @Override
@@ -70,27 +73,27 @@ final class JavaNetBufferingRequest implements Request {
 
             @Override
             public String getFirst(String headerName) {
-                return "";
+                throw new UnsupportedOperationException(HEADER_IMPLEMENTATION_IS_WRITE_ONLY);
             }
 
             @Override
             public Set<String> headerNames() {
-                return Set.of();
+                throw new UnsupportedOperationException(HEADER_IMPLEMENTATION_IS_WRITE_ONLY);
             }
 
             @Override
             public long getContentLength() {
-                return 0;
+                throw new UnsupportedOperationException(HEADER_IMPLEMENTATION_IS_WRITE_ONLY);
             }
 
             @Override
             public void setContentLength(long contentLength) {
-                // NO-OP.
+                throw new UnsupportedOperationException("Content-Length to be set by underlying framework");
             }
 
             @Override
             public ContentType getContentType() {
-                return ContentType.APPLICATION_JSON;
+                throw new UnsupportedOperationException(HEADER_IMPLEMENTATION_IS_WRITE_ONLY);
             }
 
             @Override

--- a/fahrschein-http-jdk11/src/main/java/org/zalando/fahrschein/http/jdk11/JavaNetHeadersDelegate.java
+++ b/fahrschein-http-jdk11/src/main/java/org/zalando/fahrschein/http/jdk11/JavaNetHeadersDelegate.java
@@ -54,7 +54,7 @@ final class JavaNetHeadersDelegate implements Headers {
 
     @Override
     public ContentType getContentType() {
-        return headers.firstValue("Content-Type").map(v -> ContentType.valueOf(v)).orElse(null);
+        return headers.firstValue(Headers.CONTENT_TYPE).map(v -> ContentType.valueOf(v)).orElse(null);
     }
 
     @Override

--- a/fahrschein-http-jdk11/src/main/java/org/zalando/fahrschein/http/jdk11/JavaNetHeadersDelegate.java
+++ b/fahrschein-http-jdk11/src/main/java/org/zalando/fahrschein/http/jdk11/JavaNetHeadersDelegate.java
@@ -1,0 +1,64 @@
+package org.zalando.fahrschein.http.jdk11;
+
+import org.zalando.fahrschein.http.api.ContentType;
+import org.zalando.fahrschein.http.api.Headers;
+
+import java.net.http.HttpHeaders;
+import java.util.List;
+import java.util.Set;
+
+final class JavaNetHeadersDelegate implements Headers {
+
+    private static final String HEADER_IMPLEMENTATION_IS_READ_ONLY = "Header implementation is read-only";
+
+    private final HttpHeaders headers;
+
+    JavaNetHeadersDelegate(HttpHeaders headers) {
+        this.headers = headers;
+    }
+
+    @Override
+    public List<String> get(String headerName) {
+        return headers.allValues(headerName);
+    }
+
+    @Override
+    public void add(String headerName, String value) {
+        throw new UnsupportedOperationException(HEADER_IMPLEMENTATION_IS_READ_ONLY);
+    }
+
+    @Override
+    public void put(String headerName, String value) {
+        throw new UnsupportedOperationException(HEADER_IMPLEMENTATION_IS_READ_ONLY);
+    }
+
+    @Override
+    public String getFirst(String headerName) {
+        return headers.firstValue(headerName).orElse(null);
+    }
+
+    @Override
+    public Set<String> headerNames() {
+        return headers.map().keySet();
+    }
+
+    @Override
+    public long getContentLength() {
+        return -1;
+    }
+
+    @Override
+    public void setContentLength(long contentLength) {
+        throw new UnsupportedOperationException(HEADER_IMPLEMENTATION_IS_READ_ONLY);
+    }
+
+    @Override
+    public ContentType getContentType() {
+        return headers.firstValue("Content-Type").map(v -> ContentType.valueOf(v)).orElse(null);
+    }
+
+    @Override
+    public void setContentType(ContentType contentType) {
+        throw new UnsupportedOperationException(HEADER_IMPLEMENTATION_IS_READ_ONLY);
+    }
+}

--- a/fahrschein-http-jdk11/src/main/java/org/zalando/fahrschein/http/jdk11/JavaNetResponse.java
+++ b/fahrschein-http-jdk11/src/main/java/org/zalando/fahrschein/http/jdk11/JavaNetResponse.java
@@ -28,12 +28,12 @@ final class JavaNetResponse implements Response {
             case (200): return "OK";
             case (201): return "Created";
             case (202): return "Accepted";
-            case (203): return "Non Authoritative Information";
+            case (203): return "Non-Authoritative Information";
             case (204): return "No Content";
             case (205): return "Reset Content";
             case (206): return "Partial Content";
             case (207): return "Partial Update OK";
-            case (300): return "Mutliple Choices";
+            case (300): return "Multiple Choices";
             case (301): return "Moved Permanently";
             case (302): return "Moved Temporarily";
             case (303): return "See Other";
@@ -76,13 +76,7 @@ final class JavaNetResponse implements Response {
 
     @Override
     public Headers getHeaders() {
-        Headers h = new HeadersImpl();
-        this.r.headers().map().forEach((k, vs) -> {
-            vs.stream().forEach(v -> {
-                h.add(k, v);
-            });
-        });
-        return h;
+        return new JavaNetHeadersDelegate(this.r.headers());
     }
 
     @Override

--- a/fahrschein-http-jdk11/src/test/java/org/zalando/fahrschein/http/jdk11/JavaNetHeadersDelegateTest.java
+++ b/fahrschein-http-jdk11/src/test/java/org/zalando/fahrschein/http/jdk11/JavaNetHeadersDelegateTest.java
@@ -1,0 +1,101 @@
+package org.zalando.fahrschein.http.jdk11;
+
+import org.junit.Test;
+import org.zalando.fahrschein.http.api.ContentType;
+import org.zalando.fahrschein.http.api.Headers;
+
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.util.HashSet;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class JavaNetHeadersDelegateTest {
+
+    private HttpRequest.Builder requestBuilder() {
+        return HttpRequest.newBuilder(URI.create("http://bla"));
+    }
+
+    @Test
+    public void shouldBeCaseInsensitive() {
+        final Headers headers = new JavaNetHeadersDelegate(HttpRequest.newBuilder()
+                .uri(URI.create("http://bla"))
+                .setHeader("Content-type", "text/plain").build().headers());
+
+        assertEquals(singletonList("text/plain"), headers.get("content-type"));
+        assertEquals("text/plain", headers.getFirst("CONTENT-TYPE"));
+        assertEquals("text/plain", headers.getFirst("Content-Type"));
+        assertEquals("text/plain", headers.getFirst("content-type"));
+    }
+
+    @Test
+    public void shouldReturnHeaderNames() {
+        final Headers headers = new JavaNetHeadersDelegate(requestBuilder()
+                .setHeader("Content-Type", "text/plain")
+                .setHeader("Content-Encoding", "gzip").build().headers());
+
+        assertEquals(new HashSet<>(asList("Content-Type", "Content-Encoding")), headers.headerNames());
+    }
+
+    @Test
+    public void shouldReturnEmptySetOfHeadernames() {
+        final Headers headers = new JavaNetHeadersDelegate(requestBuilder().build().headers());
+        assertEquals(emptySet(), headers.headerNames());
+    }
+
+    @Test
+    public void shouldReturnEmptyListForUnknownHeaders() {
+        final Headers headers = new JavaNetHeadersDelegate(requestBuilder().build().headers());
+        assertEquals(emptyList(), headers.get("Content-Type"));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void readOnlyViewShouldNotSupportAdd() {
+        final Headers headers = new JavaNetHeadersDelegate(requestBuilder().build().headers());
+        headers.add("Content-Type", "application/json");
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void readOnlyViewShouldNotSupportPut() {
+        final Headers headers = new JavaNetHeadersDelegate(requestBuilder()
+                .setHeader("Content-Type", "text/plain")
+                .setHeader("Content-Encoding", "gzip").build().headers());
+
+        headers.put("Content-Type", "application/json");
+    }
+
+    @Test
+    public void shouldGetContentType() {
+        final Headers headers = new JavaNetHeadersDelegate(requestBuilder()
+                .setHeader("Content-Type", "text/plain").build().headers());
+
+        final ContentType contentType = headers.getContentType();
+        assertNotNull(contentType);
+        assertEquals(ContentType.TEXT_PLAIN_VALUE, contentType.getValue());
+        assertEquals(ContentType.TEXT_PLAIN, contentType);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void shouldNotSetContentLength() {
+        final Headers headers = new JavaNetHeadersDelegate(requestBuilder().build().headers());
+        headers.setContentLength(2000L);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void shouldNotSetContentType() {
+        final Headers headers = new JavaNetHeadersDelegate(requestBuilder().build().headers());
+        headers.setContentType(ContentType.TEXT_PLAIN);
+    }
+
+    @Test
+    public void shouldReturnMinusOneForUnknownContentLength() {
+        final Headers headers = new JavaNetHeadersDelegate(requestBuilder().build().headers());
+
+        assertEquals(-1L, headers.getContentLength());
+    }
+}

--- a/fahrschein-http-jdk11/src/test/java/org/zalando/fahrschein/http/jdk11/JavaNetHeadersDelegateTest.java
+++ b/fahrschein-http-jdk11/src/test/java/org/zalando/fahrschein/http/jdk11/JavaNetHeadersDelegateTest.java
@@ -25,7 +25,7 @@ public class JavaNetHeadersDelegateTest {
     public void shouldBeCaseInsensitive() {
         final Headers headers = new JavaNetHeadersDelegate(HttpRequest.newBuilder()
                 .uri(URI.create("http://bla"))
-                .setHeader("Content-type", "text/plain").build().headers());
+                .setHeader(Headers.CONTENT_TYPE, "text/plain").build().headers());
 
         assertEquals(singletonList("text/plain"), headers.get("content-type"));
         assertEquals("text/plain", headers.getFirst("CONTENT-TYPE"));
@@ -36,8 +36,8 @@ public class JavaNetHeadersDelegateTest {
     @Test
     public void shouldReturnHeaderNames() {
         final Headers headers = new JavaNetHeadersDelegate(requestBuilder()
-                .setHeader("Content-Type", "text/plain")
-                .setHeader("Content-Encoding", "gzip").build().headers());
+                .setHeader(Headers.CONTENT_TYPE, "text/plain")
+                .setHeader(Headers.CONTENT_ENCODING, "gzip").build().headers());
 
         assertEquals(new HashSet<>(asList("Content-Type", "Content-Encoding")), headers.headerNames());
     }
@@ -51,28 +51,28 @@ public class JavaNetHeadersDelegateTest {
     @Test
     public void shouldReturnEmptyListForUnknownHeaders() {
         final Headers headers = new JavaNetHeadersDelegate(requestBuilder().build().headers());
-        assertEquals(emptyList(), headers.get("Content-Type"));
+        assertEquals(emptyList(), headers.get(Headers.CONTENT_TYPE));
     }
 
     @Test(expected = UnsupportedOperationException.class)
     public void readOnlyViewShouldNotSupportAdd() {
         final Headers headers = new JavaNetHeadersDelegate(requestBuilder().build().headers());
-        headers.add("Content-Type", "application/json");
+        headers.add(Headers.CONTENT_TYPE, "application/json");
     }
 
     @Test(expected = UnsupportedOperationException.class)
     public void readOnlyViewShouldNotSupportPut() {
         final Headers headers = new JavaNetHeadersDelegate(requestBuilder()
-                .setHeader("Content-Type", "text/plain")
-                .setHeader("Content-Encoding", "gzip").build().headers());
+                .setHeader(Headers.CONTENT_TYPE, "text/plain")
+                .setHeader(Headers.CONTENT_ENCODING, "gzip").build().headers());
 
-        headers.put("Content-Type", "application/json");
+        headers.put(Headers.CONTENT_TYPE, "application/json");
     }
 
     @Test
     public void shouldGetContentType() {
         final Headers headers = new JavaNetHeadersDelegate(requestBuilder()
-                .setHeader("Content-Type", "text/plain").build().headers());
+                .setHeader(Headers.CONTENT_TYPE, "text/plain").build().headers());
 
         final ContentType contentType = headers.getContentType();
         assertNotNull(contentType);


### PR DESCRIPTION
Introduces a delegate class to avoid copying of all headers.

Also throws 'UnsupportedOperationExceptions' in case of misuse.