### PR TITLE
Reverts the fahrschein-http-simple to runtime dependency

### DIFF
--- a/fahrschein/pom.xml
+++ b/fahrschein/pom.xml
@@ -19,7 +19,6 @@
             <groupId>org.zalando</groupId>
             <artifactId>fahrschein-http-simple</artifactId>
             <version>${project.version}</version>
-            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.zalando</groupId>


### PR DESCRIPTION
Although technically correct (there is no dependency at build time),
we want to expose the SimpleRequestFactory to users at their compile-time (!), which is
prohibited by gradle's interpretation of the pom.xml, if a dependency
is marked as runtime.

https://github.com/zalando-nakadi/fahrschein/issues/328

In a closer look, this is a valid interpretation of [the spec](https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#dependency-scope):

**runtime** This scope indicates that the dependency is not required for compilation, but is for execution. Maven includes a dependency with this scope in the runtime and test classpaths, but not the compile classpath.

