### PR TITLE
Upgrade dependencies: dropwizard-metrics, jackson-datatype-money, json-path

### DIFF
--- a/fahrschein-example/build.gradle
+++ b/fahrschein-example/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation "com.squareup.okhttp3:okhttp:${property('okhttp.version')}"
     implementation "org.apache.httpcomponents:httpclient:${property("apachehttp.version")}"
     implementation "org.springframework:spring-web:${property('spring.version')}"
-    implementation 'org.zalando:jackson-datatype-money:0.6.0'
+    implementation 'org.zalando:jackson-datatype-money:1.3.0'
     implementation "com.fasterxml.jackson.core:jackson-core:${property('jackson.version')}"
     implementation "com.fasterxml.jackson.core:jackson-annotations:${property('jackson.version')}"
     implementation "com.fasterxml.jackson.core:jackson-databind:${property('jackson.version')}"

--- a/fahrschein-metrics-dropwizard/build.gradle
+++ b/fahrschein-metrics-dropwizard/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 dependencies {
     api project(':fahrschein')
-    api 'io.dropwizard.metrics:metrics-core:3.1.2'
+    api 'io.dropwizard.metrics:metrics-core:4.2.9'
 }
 
 publishing.publications.maven.pom.description = 'Fahrschein Metrics using Dropwizard'

--- a/fahrschein/build.gradle
+++ b/fahrschein/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-annotations:${property('jackson.version')}"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${property('jackson.version')}"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${property('jackson.version')}"
-    testImplementation ('com.jayway.jsonpath:json-path:2.2.0') {
+    testImplementation ('com.jayway.jsonpath:json-path:2.7.0') {
         exclude group: "org.ow2.asm", module: "asm"
     }
     testImplementation 'org.hobsoft.hamcrest:hamcrest-compose:0.3.0'


### PR DESCRIPTION
In PR #323 we raised the topic of majorly outdated dependencies of fahrschein. These include:

    io.dropwizard.metrics:metrics-core (3.1.2 -> 4.2.9)
    org.zalando:jackson-datatype-money (0.6.0 -> 1.3.0)
    com.jayway.jsonpath:json-path (2.2.0 -> 2.7.0)

Closes #334