### PR TITLE
Analyses the CVE report, upgrades vulnerable dependencies and suppresses false-positives

### DIFF
--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -15,4 +15,4 @@ jobs:
       - uses: gradle/gradle-build-action@v2
         with:
           gradle-version: 7.4.1
-          arguments: dependencyCheckAggregate
+          arguments: ':dependencyCheckAggregate'

--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ If you want to skip end-to-end tests completely, run
 The project integrates CVE scanning to check for vulnerable dependencies. In case of build failure, this can be caused by a high-risk vulnerability in a dependency being identified. You can run the reporting locally:
 
 ```
-./gradlew dependencyCheckAggregate
+./gradlew :dependencyCheckAggregate
 open build/reports/dependency-check-report.html
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 
 // CVE vulnerability scanning
-// run: ./gradlew dependencyCheckAggregate
+// run: ./gradlew :dependencyCheckAggregate
 
 dependencyCheck {
     failBuildOnCVSS = 5

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'eclipse'
     id 'idea'
     id 'com.github.ben-manes.versions' version '0.42.0'
-    id 'org.owasp.dependencycheck' version '7.1.0.1'
+    id 'org.owasp.dependencycheck' version '7.1.1'
 }
 
 
@@ -10,5 +10,9 @@ plugins {
 // run: ./gradlew dependencyCheckAggregate
 
 dependencyCheck {
-    failBuildOnCVSS = '9'
+    failBuildOnCVSS = 5
+    suppressionFile = 'cve-suppressions.xml'
+    analyzers {
+        assemblyEnabled = false
+    }
 }

--- a/cve-suppressions.xml
+++ b/cve-suppressions.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+<suppress>
+   <notes><![CDATA[
+	   This vulnerablility is not going to be fixed by Spring. Instead, it's an inherent insecurity of
+	   Java Serialization, and the advice is not to rely on Java Serialization for untrusted data.
+   ]]></notes>
+   <cve>CVE-2016-1000027</cve>
+</suppress>
+<suppress>
+   <notes><![CDATA[
+   Kotlin is only included as transitive dependency from okhttp, therefore both CVEs don't apply.
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin\-.*$</packageUrl>
+   <cpe>cpe:/a:jetbrains:kotlin</cpe>
+   <cve>CVE-2020-29582</cve>
+   <cve>CVE-2022-24329</cve>
+</suppress>
+</suppressions>

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,9 +2,9 @@
 project.version=0.23.0
 
 ## dependency versions
-jackson.version=2.13.1
+jackson.version=2.13.3
 slf4j.version=1.7.25
-spring.version=5.3.18
+spring.version=5.3.20
 mockito.version=4.3.1
 junit.version=4.13.1
 testContainersV=1.16.2


### PR DESCRIPTION
Changes:
* Bumps dependencycheck plugin to the latest
* Bumps Jackson to 2.13.3 (CVE-2020-36518)
* Bumps Spring to 5.3.20 - not necessarily related to CVE-2016-1000027 as that is a false positive
* Ignores CVE-2016-1000027, CVE-2020-29582 and CVE-2022-24329 in scan, see
  cve-supressions.xml
* Makes build failure stricter, now triggering on CVE score 5 and above
  (only works if we specify the score as number, not as string!)
* Speeds up CVE scan by removing redundant report generation for all subprojects, and avoids scanning for DLL/EXE based vulnerabilities.

Test by running `./gradlew :dependencyCheckAggregate` locally.
