### PR TITLE
Aggregate jacoco test reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ Alternatively, run the full build and check the aggregated coverage report:
 
 ```sh
 ./gradlew check -Pe2e.skip
-open build/reports/jacoco/testCodeCoverageReport/html/index.html
+open build/reports/jacoco/jacocoAggregateReport/html/index.html
 ```
 
 ### End-to-End tests

--- a/README.md
+++ b/README.md
@@ -323,10 +323,27 @@ We use Gradle [convention plugins](https://docs.gradle.org/current/samples/sampl
 Most dependencies are defined on a per-subproject level, only the versions for the most-used shared dependencies are controlled centrally, in the [gradle.properties](./gradle.properties) file. This also allows you testing your build with a different version by specifying the property on the command-line.
 
 ```sh
-./gradlew test -Pjackson.version=2.9.0
+./gradlew check -Pjackson.version=2.9.0
 ```
 
 The [integration tests](.github/workflows/ci.yaml) include running the build with our supported baseline dependency as well as the latest micro release of Jackson, Apache HttpClient and Spring. Please update the section in the README when bumping dependency baselines, and add this to the release notes.
+
+
+### Unit Tests and Code Coverage
+
+Fahrschein automatically generates test coverage reports via its `JaCoCo` build integration. For example, you can check code coverage for a single subproject:
+
+```sh
+./gradlew fahrschein-http-api:check
+open fahrschein-http-api/build/reports/jacoco/test/html/index.html
+```
+
+Alternatively, run the full build and check the aggregated coverage report:
+
+```sh
+./gradlew check -Pe2e.skip
+open build/reports/jacoco/testCodeCoverageReport/html/index.html
+```
 
 ### End-to-End tests
 
@@ -334,12 +351,13 @@ The `fahrschein-e2e-test` module has end-to-end tests using `docker-compose`. If
 
 ```sh
 docker-compose -f fahrschein-e2e-test/src/test/resources/docker-compose.yaml up -d
-./gradlew :fahrschein-e2e:test -Pe2e.composeProvided
+./gradlew :fahrschein-e2e:check -Pe2e.composeProvided
 ```
 
 If you want to skip end-to-end tests completely, run 
+
 ```sh
-./gradlew test -Pe2e.skip
+./gradlew check -Pe2e.skip
 ```
 
 ### CVE scanning

--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ Fahrschein is a gradle-based project. For local development, Fahrschein requires
 * A local installation of JDK11
 * A local Docker installation for running integration tests
 
-When developing, make sure to run unit and integration tests with `./gradlew test`.
+When developing, make sure to run unit and integration tests with `./gradlew check`.
 
 ### Understanding the build
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'eclipse'
     id 'idea'
     id 'jacoco-report-aggregation'
+    id "org.barfuin.gradle.jacocolog" version "1.2.3"
     id 'com.github.ben-manes.versions' version '0.42.0'
     id 'org.owasp.dependencycheck' version '7.1.1'
 }
@@ -36,12 +37,12 @@ dependencies {
 
 reporting {
     reports {
-        testCodeCoverageReport(JacocoCoverageReport) {
+        jacocoAggregateReport(JacocoCoverageReport) {
             testType = TestSuiteType.UNIT_TEST
         }
     }
 }
 
 tasks.named('check') {
-    dependsOn tasks.named('testCodeCoverageReport', JacocoReport)
+    dependsOn tasks.named('jacocoAggregateReport', JacocoReport)
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,6 @@ plugins {
     id 'eclipse'
     id 'idea'
     id 'jacoco-report-aggregation'
-    id "org.barfuin.gradle.jacocolog" version "1.2.3"
     id 'com.github.ben-manes.versions' version '0.42.0'
     id 'org.owasp.dependencycheck' version '7.1.1'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,11 @@
 plugins {
+    id 'base'
     id 'eclipse'
     id 'idea'
+    id 'jacoco-report-aggregation'
     id 'com.github.ben-manes.versions' version '0.42.0'
     id 'org.owasp.dependencycheck' version '7.1.1'
 }
-
 
 // CVE vulnerability scanning
 // run: ./gradlew :dependencyCheckAggregate
@@ -15,4 +16,32 @@ dependencyCheck {
     analyzers {
         assemblyEnabled = false
     }
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    jacocoAggregation project(':fahrschein'),
+            project(':fahrschein-http-api'),
+            project(':fahrschein-http-simple'),
+            project(':fahrschein-http-apache'),
+            project(':fahrschein-http-spring'),
+            project(':fahrschein-http-jdk11'),
+            project(':fahrschein-inmemory'),
+            project(':fahrschein-metrics-dropwizard'),
+            project(':fahrschein-typeresolver')
+}
+
+reporting {
+    reports {
+        testCodeCoverageReport(JacocoCoverageReport) {
+            testType = TestSuiteType.UNIT_TEST
+        }
+    }
+}
+
+tasks.named('check') {
+    dependsOn tasks.named('testCodeCoverageReport', JacocoReport)
 }

--- a/buildSrc/src/main/groovy/fahrschein.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/fahrschein.java-conventions.gradle
@@ -17,10 +17,6 @@ java {
     }
 }
 
-test {
-    useJUnitPlatform()
-}
-
 tasks.withType(JavaCompile).configureEach {
     options.compilerArgs << '-parameters'
     options.compilerArgs << '-Xlint:all'
@@ -62,10 +58,9 @@ configurations.all {
 }
 
 test {
-    finalizedBy jacocoTestReport // report is always generated after tests run
+    useJUnitPlatform()
 }
 
-jacocoTestReport {
-    dependsOn test // tests are required to run before generating the report
+tasks.named('test') {
+    finalizedBy tasks.named('jacocoTestReport', JacocoReport)
 }
-

--- a/fahrschein-e2e-test/build.gradle
+++ b/fahrschein-e2e-test/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'fahrschein.java-conventions'
+    id 'jvm-test-suite'
 }
 
 dependencies {
@@ -17,6 +18,14 @@ dependencies {
     testImplementation "com.fasterxml.jackson.module:jackson-module-parameter-names:${property('jackson.version')}"
     testImplementation "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${property('jackson.version')}"
     testImplementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${property('jackson.version')}"
+}
+
+testing {
+    suites {
+        test {
+            testType = TestSuiteType.INTEGRATION_TEST
+        }
+    }
 }
 
 test {


### PR DESCRIPTION
## Changes

* Adds jacoco-report-aggregation plugin as described in
  https://docs.gradle.org/current/samples/sample_jvm_multi_project_with_code_coverage_standalone.html
* Documents unit test coverage integration in README.md, consistently using the parent task "check" instead of "test"
* Marks fahrschein-e2e-test as IntegrationTest type

<img width="1079" alt="Screenshot 2022-07-14 at 11 43 54" src="https://user-images.githubusercontent.com/129439/178953909-d598b8cf-9416-4b44-94c0-d40e4712e643.png">
