### PR TITLE
Disable irrelevant CVE analyzers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,14 @@ dependencyCheck {
     failBuildOnCVSS = 5
     suppressionFile = 'cve-suppressions.xml'
     analyzers {
+        experimentalEnabled = false
         assemblyEnabled = false
+        msbuildEnabled = false
+        nodeEnabled = false
+        nuspecEnabled = false
+        retirejs {
+            enabled = false
+        }
     }
 }
 


### PR DESCRIPTION
Disable analyzers which don't matter to Fahrschein, according to this list:

https://jeremylong.github.io/DependencyCheck/dependency-check-gradle/configuration.html

## Background

Many analyzers are auto-enabled, including RetireJS, a javascript analyzer. The RetireJS analyzer contained an invalid rule in master (2) (3), which got pulled in by the CVE scan, this broke the nightly CVE scan (1). 

## References

1. https://github.com/zalando-nakadi/fahrschein/runs/7491798097?check_suite_focus=true
2. Broken here: https://github.com/RetireJS/retire.js/commit/60ffbeb1523c503da886b2a47b39551697ed06c8
3. Fixed shortly after: https://github.com/RetireJS/retire.js/commit/7007575f637b840016edf8a9512d608f00795b1b
