### PR TITLE
Drain InputStream on closing

### DIFF
--- a/fahrschein-http-api/src/main/java/org/zalando/fahrschein/http/api/StreamUtils.java
+++ b/fahrschein-http-api/src/main/java/org/zalando/fahrschein/http/api/StreamUtils.java
@@ -1,0 +1,30 @@
+package org.zalando.fahrschein.http.api;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class StreamUtils {
+
+    /**
+     * The default buffer size used when copying bytes.
+     */
+    public static final int BUFFER_SIZE = 4096;
+
+    /**
+     * Drain the remaining content of the given InputStream.
+     * <p>Leaves the InputStream open when done.
+     * @param in the InputStream to drain
+     * @return the number of bytes read
+     * @throws IOException in case of I/O errors
+     */
+    public static int drain(InputStream in) throws IOException {
+        byte[] buffer = new byte[BUFFER_SIZE];
+        int bytesRead = -1;
+        int byteCount = 0;
+        while ((bytesRead = in.read(buffer)) != -1) {
+            byteCount += bytesRead;
+        }
+        return byteCount;
+    }
+
+}

--- a/fahrschein-http-jdk11/src/main/java/org/zalando/fahrschein/http/jdk11/JavaNetResponse.java
+++ b/fahrschein-http-jdk11/src/main/java/org/zalando/fahrschein/http/jdk11/JavaNetResponse.java
@@ -3,6 +3,7 @@ package org.zalando.fahrschein.http.jdk11;
 import org.zalando.fahrschein.http.api.Headers;
 import org.zalando.fahrschein.http.api.HeadersImpl;
 import org.zalando.fahrschein.http.api.Response;
+import org.zalando.fahrschein.http.api.StreamUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -90,6 +91,7 @@ final class JavaNetResponse implements Response {
     @Override
     public void close() {
         try {
+            StreamUtils.drain(r.body());
             r.body().close();
         } catch (Exception e) {
             // ignore

--- a/fahrschein-http-simple/src/main/java/org/zalando/fahrschein/http/simple/SimpleBufferingRequest.java
+++ b/fahrschein-http-simple/src/main/java/org/zalando/fahrschein/http/simple/SimpleBufferingRequest.java
@@ -13,7 +13,6 @@ import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
-import java.util.zip.GZIPOutputStream;
 
 /**
  * {@link Request} implementation that uses standard JDK facilities to

--- a/fahrschein-http-simple/src/main/java/org/zalando/fahrschein/http/simple/SimpleResponse.java
+++ b/fahrschein-http-simple/src/main/java/org/zalando/fahrschein/http/simple/SimpleResponse.java
@@ -3,6 +3,7 @@ package org.zalando.fahrschein.http.simple;
 import org.zalando.fahrschein.http.api.Headers;
 import org.zalando.fahrschein.http.api.HeadersImpl;
 import org.zalando.fahrschein.http.api.Response;
+import org.zalando.fahrschein.http.api.StreamUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -80,6 +81,7 @@ final class SimpleResponse implements Response {
     public void close() {
         if (this.responseStream != null) {
             try {
+                StreamUtils.drain(this.responseStream);
                 this.responseStream.close();
             }
             catch (IOException ex) {


### PR DESCRIPTION
The HTTP client facade code is original from spring, and the code for closing has diverged since. They have introduced a bug-fix to ensure that the InputStreams are properly drained, so the connections can be given back to the connection pools without resource leaks.

Closes #303

Changes:
* New StreamUtils helper class with static method to "drain"
* Calling drain() in fahrschein-http-simple and fahrschein-http-jdk11
* Slight refactoring of the apache client, to capture its InputStream for draining.
