### PR TITLE
Fixes Jackson Vulnerabilities: CVE-2022-42003, CVE-2022-42004

### DIFF
--- a/fahrschein-e2e-test/build.gradle
+++ b/fahrschein-e2e-test/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     testImplementation "org.testcontainers:testcontainers:1.17.2"
     testImplementation "com.fasterxml.jackson.core:jackson-core:${property('jackson.version')}"
     testImplementation "com.fasterxml.jackson.core:jackson-annotations:${property('jackson.version')}"
-    testImplementation "com.fasterxml.jackson.core:jackson-databind:${property('jackson.version')}"
+    testImplementation "com.fasterxml.jackson.core:jackson-databind:${property('jackson_databind.version')}"
     testImplementation "com.fasterxml.jackson.module:jackson-module-parameter-names:${property('jackson.version')}"
     testImplementation "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${property('jackson.version')}"
     testImplementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${property('jackson.version')}"

--- a/fahrschein-example/build.gradle
+++ b/fahrschein-example/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation 'org.zalando:jackson-datatype-money:1.3.0'
     implementation "com.fasterxml.jackson.core:jackson-core:${property('jackson.version')}"
     implementation "com.fasterxml.jackson.core:jackson-annotations:${property('jackson.version')}"
-    implementation "com.fasterxml.jackson.core:jackson-databind:${property('jackson.version')}"
+    implementation "com.fasterxml.jackson.core:jackson-databind:${property('jackson_databind.version')}"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${property('jackson.version')}"
     implementation "io.opentelemetry:opentelemetry-sdk-testing:${property('opentelemetry.version')}"
     implementation "io.opentelemetry:opentelemetry-extension-trace-propagators:${property('opentelemetry.version')}"

--- a/fahrschein-typeresolver/build.gradle
+++ b/fahrschein-typeresolver/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     api project(':fahrschein')
     api "com.fasterxml.jackson.core:jackson-core:${property('jackson.version')}"
     api "com.fasterxml.jackson.core:jackson-annotations:${property('jackson.version')}"
-    api "com.fasterxml.jackson.core:jackson-databind:${property('jackson.version')}"
+    api "com.fasterxml.jackson.core:jackson-databind:${property('jackson_databind.version')}"
 }
 
 publishing.publications.maven.pom.description = 'Fahrschein Type Resolver'

--- a/fahrschein/build.gradle
+++ b/fahrschein/build.gradle
@@ -6,7 +6,7 @@ plugins {
 dependencies {
     api project(':fahrschein-http-api')
     api project(':fahrschein-http-simple')
-    api "com.fasterxml.jackson.core:jackson-databind:${property('jackson.version')}"
+    api "com.fasterxml.jackson.core:jackson-databind:${property('jackson_databind.version')}"
     implementation "com.fasterxml.jackson.module:jackson-module-parameter-names:${property('jackson.version')}"
     implementation "com.fasterxml.jackson.core:jackson-core:${property('jackson.version')}"
     implementation "com.fasterxml.jackson.core:jackson-annotations:${property('jackson.version')}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,8 @@
 project.version=0.24.1
 
 ## dependency versions
-jackson.version=2.13.3
+jackson.version=2.13.4
+jackson_databind.version=2.13.4.2
 slf4j.version=1.7.25
 spring.version=5.3.20
 mockito.version=4.3.1


### PR DESCRIPTION
## Vulnerabilities

* https://nvd.nist.gov/vuln/detail/CVE-2022-42003 - In FasterXML jackson-databind before 2.14.0-rc1, resource exhaustion can occur because of a lack of a check in primitive value deserializers to avoid deep wrapper array nesting, when the UNWRAP_SINGLE_VALUE_ARRAYS feature is enabled. Additional fix version in 2.13.4.1 and 2.12.17.1
* https://nvd.nist.gov/vuln/detail/CVE-2022-42004 - In FasterXML jackson-databind before 2.13.4, resource exhaustion can occur because of a lack of a check in BeanDeserializer._deserializeFromArray to prevent use of deeply nested arrays. An application is vulnerable only with certain customized choices for deserialization.

## Changes

Only jackson-databind got updated to 2.13.4.2. For maximum consistency, we're bumping the other jackson modules to 2.13.4.

## Context

Caught by nightly CVE checks https://github.com/zalando-nakadi/fahrschein/actions/runs/3305332044/jobs/5455363764
