### PR TITLE
To log "info" in NakadiReader

### DIFF
--- a/fahrschein/src/main/java/org/zalando/fahrschein/StreamBuilders.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/StreamBuilders.java
@@ -76,8 +76,10 @@ class StreamBuilders {
             final MetricsCollector metricsCollector = this.metricsCollector != null ? this.metricsCollector : NoMetricsCollector.NO_METRICS_COLLECTOR;
             final BatchHandler batchHandler = this.batchHandler != null ? this.batchHandler : DefaultBatchHandler.INSTANCE;
 
-            return new NakadiReader<>(uri, requestFactory, backoffStrategy, cursorManager,
-                    eventNames, subscription, lock, eventReader, listener, batchHandler, metricsCollector);
+            return new NakadiReader<>(
+                    uri, requestFactory, backoffStrategy, cursorManager,
+                    eventNames, subscription, lock, eventReader, listener, batchHandler,
+                    metricsCollector, StreamInfoReader.getDefault());
         }
 
         @Override

--- a/fahrschein/src/main/java/org/zalando/fahrschein/StreamInfo.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/StreamInfo.java
@@ -1,0 +1,4 @@
+package org.zalando.fahrschein;
+
+public class StreamInfo {
+}

--- a/fahrschein/src/main/java/org/zalando/fahrschein/StreamInfo.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/StreamInfo.java
@@ -1,4 +1,0 @@
-package org.zalando.fahrschein;
-
-public class StreamInfo {
-}

--- a/fahrschein/src/main/java/org/zalando/fahrschein/StreamInfoReader.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/StreamInfoReader.java
@@ -1,0 +1,43 @@
+package org.zalando.fahrschein;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+
+import java.io.IOException;
+import java.util.Optional;
+
+public interface StreamInfoReader {
+
+    Optional<String> readDebug(JsonParser parser) throws IOException;
+
+    static StreamInfoReader getDefault() {
+        return new DefaultImpl();
+    }
+
+    class DefaultImpl implements StreamInfoReader {
+
+        @Override
+        public Optional<String> readDebug(JsonParser parser) throws IOException {
+            Optional<String> debug = Optional.empty();
+
+            JsonParserHelper.expectToken(parser, JsonToken.START_OBJECT);
+            while(parser.nextToken() != JsonToken.END_OBJECT) {
+                final String currentFieldName = parser.getCurrentName();
+                switch (currentFieldName) {
+                    case "debug":
+                        debug = Optional.ofNullable(parser.nextTextValue());
+                        break;
+                    default:
+                        parser.nextToken();
+                        parser.skipChildren();
+                        break;
+                }
+            }
+            return debug;
+        }
+
+
+
+    }
+
+}

--- a/fahrschein/src/test/java/org/zalando/fahrschein/NakadiReaderTest.java
+++ b/fahrschein/src/test/java/org/zalando/fahrschein/NakadiReaderTest.java
@@ -51,6 +51,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -377,7 +378,7 @@ public class NakadiReaderTest {
     @Test
     public void shouldProcessEventsAndCommitCursor() throws IOException, EventAlreadyProcessedException {
         final Response response = mock(Response.class);
-        String input = "{\"cursor\":{\"event_type\":\""+EVENT_NAME+"\",\"partition\":\"123\",\"offset\":\"456\"},\"events\":[{\"id\":\"789\"}]}";
+        String input = "{\"cursor\":{\"event_type\":\""+EVENT_NAME+"\",\"partition\":\"123\",\"offset\":\"456\"},\"events\":[{\"id\":\"789\"}], \"info\": {\"debug\":\"DEBUG INFO\"}}";
         final ByteArrayInputStream initialInputStream = new ByteArrayInputStream(input.getBytes("utf-8"));
         final ByteArrayInputStream emptyInputStream = new ByteArrayInputStream(new byte[0]);
         when(response.getBody()).thenReturn(initialInputStream, emptyInputStream);
@@ -523,7 +524,13 @@ public class NakadiReaderTest {
 
         final List<String> ids = new ArrayList<>();
 
-        final NakadiReader<String> nakadiReader = new NakadiReader<>(uri, RequestFactory, backoffStrategy, cursorManager, Collections.singleton(EVENT_NAME), Optional.empty(), Optional.empty(), new StringPropertyExtractingEventReader("id"), ids::addAll, DefaultBatchHandler.INSTANCE, NoMetricsCollector.NO_METRICS_COLLECTOR);
+        final NakadiReader<String> nakadiReader = new NakadiReader<>(
+                uri, RequestFactory, backoffStrategy, cursorManager,
+                Collections.singleton(EVENT_NAME),
+                Optional.empty(), Optional.empty(),
+                new StringPropertyExtractingEventReader("id"), ids::addAll,
+                DefaultBatchHandler.INSTANCE, NoMetricsCollector.NO_METRICS_COLLECTOR,
+                StreamInfoReader.getDefault());
 
         BackoffException expectedException = assertThrows(BackoffException.class, () -> {
             nakadiReader.runInternal();
@@ -549,7 +556,12 @@ public class NakadiReaderTest {
 
         final List<String> ids = new ArrayList<>();
 
-        final NakadiReader<String> nakadiReader = new NakadiReader<>(uri, RequestFactory, backoffStrategy, cursorManager, Collections.singleton(EVENT_NAME), Optional.empty(), Optional.empty(), new StringPropertyExtractingEventReader("id"), ids::addAll, DefaultBatchHandler.INSTANCE, NoMetricsCollector.NO_METRICS_COLLECTOR);
+        final NakadiReader<String> nakadiReader = new NakadiReader<>(
+                uri, RequestFactory, backoffStrategy, cursorManager,
+                Collections.singleton(EVENT_NAME), Optional.empty(), Optional.empty(),
+                new StringPropertyExtractingEventReader("id"), ids::addAll,
+                DefaultBatchHandler.INSTANCE, NoMetricsCollector.NO_METRICS_COLLECTOR,
+                StreamInfoReader.getDefault());
 
         BackoffException expectedException = assertThrows(BackoffException.class, () -> {
             nakadiReader.runInternal();
@@ -729,5 +741,8 @@ public class NakadiReaderTest {
                 () -> assertThat(expectedException.getCause(), instanceOf(cause)),
                 () -> assertThat(expectedException.getCause().getMessage(), containsString(errorMessage)));
     }
+
+
+
 
 }

--- a/fahrschein/src/test/java/org/zalando/fahrschein/StreamInfoReaderTest.java
+++ b/fahrschein/src/test/java/org/zalando/fahrschein/StreamInfoReaderTest.java
@@ -1,0 +1,204 @@
+package org.zalando.fahrschein;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.zalando.fahrschein.http.api.Request;
+import org.zalando.fahrschein.http.api.RequestFactory;
+import org.zalando.fahrschein.http.api.Response;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class StreamInfoReaderTest {
+
+    private static final String EVENT_NAME = "some-event";
+    private final URI uri = URI.create("http://example.com/events");
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final CursorManager cursorManager = mock(CursorManager.class);
+    private final RequestFactory RequestFactory = mock(RequestFactory.class);
+
+    @SuppressWarnings("unchecked")
+    private final Listener<NakadiReaderTest.SomeEvent> listener = (Listener<NakadiReaderTest.SomeEvent>)mock(Listener.class);
+
+    class LastResult<E> implements Answer {
+        E lastResult = null;
+
+        @Override
+        public Object answer(InvocationOnMock invocation) throws Throwable {
+            lastResult = (E)  invocation.callRealMethod();
+            return lastResult;
+        }
+    }
+
+    private void assertBackoffException(BackoffException expectedException, int retries, Class<? extends Exception> cause, String errorMessage) {
+        assertAll("expectedException",
+                () -> assertThat(expectedException.getRetries(), is(retries)),
+                () -> assertThat(expectedException.getCause(), instanceOf(cause)),
+                () -> assertThat(expectedException.getCause().getMessage(), containsString(errorMessage)));
+    }
+
+    // Tests
+
+    @Test
+    public void shouldExtraxctStreamInfoDebug() throws IOException {
+        final Response response = mock(Response.class);
+        final ByteArrayInputStream initialInputStream = new ByteArrayInputStream("{\"cursor\":{\"partition\":\"0\",\"offset\":\"0\"},\"events\":[{\"id\":\"1\",\"foo\":\"bar\"},{}], \"info\":{\"debug\":\"DEBUG INFO\"}}".getBytes("utf-8"));
+        final ByteArrayInputStream emptyInputStream = new ByteArrayInputStream(new byte[0]);
+        when(response.getBody()).thenReturn(initialInputStream, emptyInputStream);
+
+        final Request request = mock(Request.class);
+        when(request.execute()).thenReturn(response);
+
+        when(RequestFactory.createRequest(uri, "GET")).thenReturn(request);
+
+        final NoBackoffStrategy backoffStrategy = new NoBackoffStrategy();
+
+        StreamInfoReader streamInfoReader = spy(StreamInfoReader.getDefault());
+        LastResult<Optional<String>> lastResult = new LastResult<>();
+        doAnswer(lastResult).when(streamInfoReader).readDebug(ArgumentMatchers.any());
+
+        final List<String> ids = new ArrayList<>();
+
+        final NakadiReader<String> nakadiReader = new NakadiReader<>(
+                uri, RequestFactory, backoffStrategy, cursorManager,
+                Collections.singleton(EVENT_NAME),
+                Optional.empty(), Optional.empty(),
+                new StringPropertyExtractingEventReader("id"), ids::addAll,
+                DefaultBatchHandler.INSTANCE, NoMetricsCollector.NO_METRICS_COLLECTOR,
+                streamInfoReader);
+
+        BackoffException expectedException = assertThrows(BackoffException.class, () -> {
+            nakadiReader.runInternal();
+        });
+
+        assertBackoffException(expectedException, 0, IOException.class, "Stream was closed");
+        verify(streamInfoReader).readDebug(ArgumentMatchers.any());
+        assertEquals(lastResult.lastResult.get(), "DEBUG INFO");
+    }
+
+    @Test
+    public void shouldNotFailBecauseOfNonDebug() throws IOException {
+        final Response response = mock(Response.class);
+        final ByteArrayInputStream initialInputStream = new ByteArrayInputStream("{\"cursor\":{\"partition\":\"0\",\"offset\":\"0\"},\"events\":[{\"id\":\"1\",\"foo\":\"bar\"},{}], \"info\":{\"a-different-key\":\"no-value\"}}".getBytes("utf-8"));
+        final ByteArrayInputStream emptyInputStream = new ByteArrayInputStream(new byte[0]);
+        when(response.getBody()).thenReturn(initialInputStream, emptyInputStream);
+
+        final Request request = mock(Request.class);
+        when(request.execute()).thenReturn(response);
+
+        when(RequestFactory.createRequest(uri, "GET")).thenReturn(request);
+
+        final NoBackoffStrategy backoffStrategy = new NoBackoffStrategy();
+
+        StreamInfoReader streamInfoReader = spy(StreamInfoReader.getDefault());
+        LastResult<Optional<String>> lastResult = new LastResult<>();
+        doAnswer(lastResult).when(streamInfoReader).readDebug(any());
+
+
+        final List<String> ids = new ArrayList<>();
+
+        final NakadiReader<String> nakadiReader = new NakadiReader<>(
+                uri, RequestFactory, backoffStrategy, cursorManager,
+                Collections.singleton(EVENT_NAME),
+                Optional.empty(), Optional.empty(),
+                new StringPropertyExtractingEventReader("id"), ids::addAll,
+                DefaultBatchHandler.INSTANCE, NoMetricsCollector.NO_METRICS_COLLECTOR,
+                streamInfoReader);
+
+        BackoffException expectedException = assertThrows(BackoffException.class, () -> {
+            nakadiReader.runInternal();
+        });
+
+        assertBackoffException(expectedException, 0, IOException.class, "Stream was closed");
+        assertThat("There shouldn't be a debug value!", !lastResult.lastResult.isPresent());
+    }
+
+    @Test
+    public void shouldNotFailBecauseOfEmptyInfo() throws IOException {
+        final Response response = mock(Response.class);
+        final ByteArrayInputStream initialInputStream = new ByteArrayInputStream("{\"cursor\":{\"partition\":\"0\",\"offset\":\"0\"},\"events\":[{\"id\":\"1\",\"foo\":\"bar\"},{}], \"info\":{}}".getBytes("utf-8"));
+        final ByteArrayInputStream emptyInputStream = new ByteArrayInputStream(new byte[0]);
+        when(response.getBody()).thenReturn(initialInputStream, emptyInputStream);
+
+        final Request request = mock(Request.class);
+        when(request.execute()).thenReturn(response);
+
+        when(RequestFactory.createRequest(uri, "GET")).thenReturn(request);
+
+        final NoBackoffStrategy backoffStrategy = new NoBackoffStrategy();
+
+        StreamInfoReader streamInfoReader = spy(StreamInfoReader.getDefault());
+        LastResult<Optional<String>> lastResult = new LastResult<>();
+        doAnswer(lastResult).when(streamInfoReader).readDebug(any());
+
+        final List<String> ids = new ArrayList<>();
+
+        final NakadiReader<String> nakadiReader = new NakadiReader<>(
+                uri, RequestFactory, backoffStrategy, cursorManager,
+                Collections.singleton(EVENT_NAME),
+                Optional.empty(), Optional.empty(),
+                new StringPropertyExtractingEventReader("id"), ids::addAll,
+                DefaultBatchHandler.INSTANCE, NoMetricsCollector.NO_METRICS_COLLECTOR,
+                streamInfoReader);
+
+        BackoffException expectedException = assertThrows(BackoffException.class, () -> {
+            nakadiReader.runInternal();
+        });
+
+        assertBackoffException(expectedException, 0, IOException.class, "Stream was closed");
+        assertThat("There shouldn't be a debug value!", !lastResult.lastResult.isPresent());
+
+    }
+
+    @Test
+    public void shouldBeFineForNoInfo() throws IOException {
+        final Response response = mock(Response.class);
+        final ByteArrayInputStream initialInputStream = new ByteArrayInputStream("{\"cursor\":{\"partition\":\"0\",\"offset\":\"0\"},\"events\":[{\"id\":\"1\",\"foo\":\"bar\"},{}]}".getBytes("utf-8"));
+        final ByteArrayInputStream emptyInputStream = new ByteArrayInputStream(new byte[0]);
+        when(response.getBody()).thenReturn(initialInputStream, emptyInputStream);
+
+        final Request request = mock(Request.class);
+        when(request.execute()).thenReturn(response);
+
+        when(RequestFactory.createRequest(uri, "GET")).thenReturn(request);
+
+        final NoBackoffStrategy backoffStrategy = new NoBackoffStrategy();
+
+        StreamInfoReader streamInfoReader = spy(StreamInfoReader.getDefault());
+
+        final List<String> ids = new ArrayList<>();
+
+        final NakadiReader<String> nakadiReader = new NakadiReader<>(
+                uri, RequestFactory, backoffStrategy, cursorManager,
+                Collections.singleton(EVENT_NAME),
+                Optional.empty(), Optional.empty(),
+                new StringPropertyExtractingEventReader("id"), ids::addAll,
+                DefaultBatchHandler.INSTANCE, NoMetricsCollector.NO_METRICS_COLLECTOR,
+                streamInfoReader);
+
+        BackoffException expectedException = assertThrows(BackoffException.class, () -> {
+            nakadiReader.runInternal();
+        });
+
+        assertBackoffException(expectedException, 0, IOException.class, "Stream was closed");
+        verify(streamInfoReader, never()).readDebug(any());
+    }
+
+
+}


### PR DESCRIPTION
In every Nakadi batch, an `info.debug` field might be available which helps to understand what's happening to the connection. (e.g. if connection is going to be closed from server side)

In this small PR I'm adding this capability to the `NakadiReader` to log value of `info.debug` instead of ignoring it.