### PR TITLE
Removing Othon Crelier from the maintainers' list

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,3 +1,2 @@
-Othon Crelier <othon.crelier@zalando.de>
 Oliver Trosien <oliver.trosien@zalando.de>
 Malte Pickhan <malte.pickhan@zalando.de>


### PR DESCRIPTION
Othon will no longer be a maintainer of Fahrschein after switching back to the management track at Zalando.