### PR TITLE
Fix false CVE positive (by upgrading the dependencycheck plugin)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'idea'
     id 'jacoco-report-aggregation'
     id 'com.github.ben-manes.versions' version '0.44.0'
-    id 'org.owasp.dependencycheck' version '7.4.0'
+    id 'org.owasp.dependencycheck' version '7.4.3'
     id 'de.thetaphi.forbiddenapis' version '3.4'
 }
 


### PR DESCRIPTION
Nightly CVE scan fails with this error:

```
One or more dependencies were identified with known vulnerabilities in fahrschein-parent:

commons-codec-1.11.jar (pkg:maven/commons-codec/commons-codec@1.11, cpe:2.3:a:apache:commons_net:1.11:*:*:*:*:*:*:*) : CVE-2021-37533
commons-logging-1.2.jar (pkg:maven/commons-logging/commons-logging@1.2, cpe:2.3:a:apache:commons_net:1.2:*:*:*:*:*:*:*) : CVE-2021-37533
```

Both vulnerabilities affect commons-net, so these are false positives.

