### PR TITLE
Add support for zalando platform IAM

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ meta
     └── example-token-type
 ```
 
+The resulting token would be "Bearer your-secret-token"
+
 #### Custom authorization
 
 One can override `AuthorizationProvider` interface to support custom authorization flow.
@@ -87,7 +89,7 @@ class CustomAuthorization implements AuthorizationProvider{
 
     @Override
     public String getAuthorizationHeader() throws IOException {
-        return "null";
+        return "your-secret-token";
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ final Listener<SalesOrderPlaced> listener = events -> {
 // Configure client, defaults to using the high level api with ManagedCursorManger, 
 // using the SimpleRequestFactory without compression
 final NakadiClient nakadiClient = NakadiClient.builder(NAKADI_URI, new SimpleRequestFactory(ContentEncoding.IDENTITY))
-        .withAccessTokenProvider(new ZignAccessTokenProvider())
+        .withAccessTokenProvider(new PlatformAccessTokenProvider())
         .build();
 
 // Create subscription using the high level api
@@ -63,6 +63,39 @@ nakadiClient.stream(subscription)
 ```
 
 See [`Main.java`](fahrschein-example/src/main/java/org/zalando/fahrschein/example/Main.java) for an executable version of the above code.
+
+### OAuth support
+
+#### Default usage of PlatformAccessTokenProvider
+By default fahrschein supports implementation of [Zalando platofrm IAM (OAuth 2.0)](https://kubernetes-on-aws.readthedocs.io/en/latest/user-guide/zalando-iam.html) through `PlatformAccessTokenProvider`. The implementation
+expects a mounted directory with the below structure.
+```
+meta
+└── credentials
+    ├── example-token-secret
+    └── example-token-type
+```
+
+#### Custom authorization
+
+One can override `AuthorizationProvider` interface to support custom authorization flow.
+
+Example:
+```
+//Create custom authorization
+class CustomAuthorization implements AuthorizationProvider{
+
+    @Override
+    public String getAuthorizationHeader() throws IOException {
+        return "null";
+    }
+}
+
+final NakadiClient nakadiClient = NakadiClient.builder(NAKADI_URI, new SimpleRequestFactory(ContentEncoding.IDENTITY))
+        .withAccessTokenProvider(new CustomAuthorization())
+        .build();
+```
+
 
 ## Initializing partition offsets
 
@@ -93,7 +126,7 @@ Postgres and Redis cursor managers have been DEPRECATED and removed in version 0
 final CursorManager cursorManager = new InMemoryCursorManager();
 
 final NakadiClient nakadiClient = NakadiClient.builder(NAKADI_URI, new SimpleRequestFactory(ContentEncoding.IDENTITY))
-        .withAccessTokenProvider(new ZignAccessTokenProvider())
+        .withAccessTokenProvider(new PlatformAccessTokenProvider())
         .withCursorManager(cursorManager)
         .build();
 
@@ -213,7 +246,7 @@ final CloseableHttpClient httpClient = HttpClients.custom()
 final RequestFactory requestFactory = new HttpComponentsRequestFactory(httpClient, ContentEncoding.GZIP);
 
 final NakadiClient nakadiClient = NakadiClient.builder(NAKADI_URI, requestFactory)
-        .withAccessTokenProvider(new ZignAccessTokenProvider())
+        .withAccessTokenProvider(new PlatformAccessTokenProvider())
         .build();
 ```
 
@@ -236,7 +269,7 @@ final ClientHttpRequestFactory clientHttpRequestFactory = new OkHttp3ClientHttpR
 final RequestFactory requestFactory = new SpringRequestFactory(clientHttpRequestFactory, ContentEncoding.GZIP);
 
 final NakadiClient nakadiClient = NakadiClient.builder(NAKADI_URI, requestFactory)
-        .withAccessTokenProvider(new ZignAccessTokenProvider())
+        .withAccessTokenProvider(new PlatformAccessTokenProvider())
         .build();
 
 ```

--- a/fahrschein-example/src/main/java/org/zalando/fahrschein/example/ConsumerExample.java
+++ b/fahrschein-example/src/main/java/org/zalando/fahrschein/example/ConsumerExample.java
@@ -19,6 +19,7 @@ import org.zalando.jackson.datatype.money.MoneyModule;
 
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Paths;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -60,7 +61,7 @@ public class ConsumerExample {
 
         final NakadiClient nakadiClient = NakadiClient
                 .builder(NAKADI_URI, new SimpleRequestFactory(ContentEncoding.IDENTITY))
-                .withAccessTokenProvider(new PlatformAccessTokenProvider("./fahrschein-example/src/main/resources/meta/credentials","nakadi")).build();
+                .withAccessTokenProvider(new PlatformAccessTokenProvider(Paths.get("./fahrschein-example/src/main/resources/meta/credentials"),"nakadi")).build();
 
         final Set<String> events = new HashSet<>(asList(ORDER_CREATED, ORDER_PAYMENT_STATUS_ACCEPTED));
 

--- a/fahrschein-example/src/main/java/org/zalando/fahrschein/example/ConsumerExample.java
+++ b/fahrschein-example/src/main/java/org/zalando/fahrschein/example/ConsumerExample.java
@@ -9,7 +9,7 @@ import org.zalando.fahrschein.ExponentialBackoffStrategy;
 import org.zalando.fahrschein.Listener;
 import org.zalando.fahrschein.NakadiClient;
 import org.zalando.fahrschein.StreamParameters;
-import org.zalando.fahrschein.domain.PlatformAccessTokenProvider;
+import org.zalando.fahrschein.PlatformAccessTokenProvider;
 import org.zalando.fahrschein.domain.Subscription;
 import org.zalando.fahrschein.example.domain.MultiEventProcessor;
 import org.zalando.fahrschein.example.domain.OrderEvent;

--- a/fahrschein-example/src/main/java/org/zalando/fahrschein/example/ConsumerExample.java
+++ b/fahrschein-example/src/main/java/org/zalando/fahrschein/example/ConsumerExample.java
@@ -9,7 +9,7 @@ import org.zalando.fahrschein.ExponentialBackoffStrategy;
 import org.zalando.fahrschein.Listener;
 import org.zalando.fahrschein.NakadiClient;
 import org.zalando.fahrschein.StreamParameters;
-import org.zalando.fahrschein.ZignAccessTokenProvider;
+import org.zalando.fahrschein.domain.PlatformAccessTokenProvider;
 import org.zalando.fahrschein.domain.Subscription;
 import org.zalando.fahrschein.example.domain.MultiEventProcessor;
 import org.zalando.fahrschein.example.domain.OrderEvent;
@@ -60,7 +60,7 @@ public class ConsumerExample {
 
         final NakadiClient nakadiClient = NakadiClient
                 .builder(NAKADI_URI, new SimpleRequestFactory(ContentEncoding.IDENTITY))
-                .withAccessTokenProvider(new ZignAccessTokenProvider()).build();
+                .withAccessTokenProvider(new PlatformAccessTokenProvider("./fahrschein-example/src/main/resources/meta/credentials","nakadi")).build();
 
         final Set<String> events = new HashSet<>(asList(ORDER_CREATED, ORDER_PAYMENT_STATUS_ACCEPTED));
 

--- a/fahrschein-example/src/main/java/org/zalando/fahrschein/example/ProducerExample.java
+++ b/fahrschein-example/src/main/java/org/zalando/fahrschein/example/ProducerExample.java
@@ -23,6 +23,7 @@ import org.zalando.jackson.datatype.money.MoneyModule;
 
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Paths;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
@@ -58,7 +59,7 @@ public class ProducerExample {
         final NakadiClient nakadiClient = NakadiClient
                 .builder(NAKADI_URI, new SimpleRequestFactory(ContentEncoding.IDENTITY))
                 .withObjectMapper(getObjectMapper())
-                .withAccessTokenProvider(new PlatformAccessTokenProvider("./fahrschein-example/src/main/resources/meta/credentials","nakadi")).build();
+                .withAccessTokenProvider(new PlatformAccessTokenProvider(Paths.get("./fahrschein-example/src/main/resources/meta/credentials"),"nakadi")).build();
 
         while (true) {
             Span span = tracer.spanBuilder("publish_orders").startSpan();

--- a/fahrschein-example/src/main/java/org/zalando/fahrschein/example/ProducerExample.java
+++ b/fahrschein-example/src/main/java/org/zalando/fahrschein/example/ProducerExample.java
@@ -12,8 +12,8 @@ import org.javamoney.moneta.Money;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.zalando.fahrschein.NakadiClient;
-import org.zalando.fahrschein.ZignAccessTokenProvider;
 import org.zalando.fahrschein.domain.Metadata;
+import org.zalando.fahrschein.domain.PlatformAccessTokenProvider;
 import org.zalando.fahrschein.example.domain.MultiEventProcessor;
 import org.zalando.fahrschein.example.domain.OrderCreatedEvent;
 import org.zalando.fahrschein.http.api.ContentEncoding;
@@ -58,7 +58,7 @@ public class ProducerExample {
         final NakadiClient nakadiClient = NakadiClient
                 .builder(NAKADI_URI, new SimpleRequestFactory(ContentEncoding.IDENTITY))
                 .withObjectMapper(getObjectMapper())
-                .withAccessTokenProvider(new ZignAccessTokenProvider()).build();
+                .withAccessTokenProvider(new PlatformAccessTokenProvider("./fahrschein-example/src/main/resources/meta/credentials","nakadi")).build();
 
         while (true) {
             Span span = tracer.spanBuilder("publish_orders").startSpan();

--- a/fahrschein-example/src/main/java/org/zalando/fahrschein/example/ProducerExample.java
+++ b/fahrschein-example/src/main/java/org/zalando/fahrschein/example/ProducerExample.java
@@ -13,7 +13,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.zalando.fahrschein.NakadiClient;
 import org.zalando.fahrschein.domain.Metadata;
-import org.zalando.fahrschein.domain.PlatformAccessTokenProvider;
+import org.zalando.fahrschein.PlatformAccessTokenProvider;
 import org.zalando.fahrschein.example.domain.MultiEventProcessor;
 import org.zalando.fahrschein.example.domain.OrderCreatedEvent;
 import org.zalando.fahrschein.http.api.ContentEncoding;

--- a/fahrschein-example/src/main/resources/meta/credentials/nakadi-token-secret
+++ b/fahrschein-example/src/main/resources/meta/credentials/nakadi-token-secret
@@ -1,0 +1,1 @@
+some-secret-token

--- a/fahrschein/build.gradle
+++ b/fahrschein/build.gradle
@@ -12,6 +12,11 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-annotations:${property('jackson.version')}"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${property('jackson.version')}"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${property('jackson.version')}"
+    compileOnly 'org.projectlombok:lombok:1.18.26'
+    annotationProcessor 'org.projectlombok:lombok:1.18.26'
+
+    testCompileOnly 'org.projectlombok:lombok:1.18.26'
+    testAnnotationProcessor 'org.projectlombok:lombok:1.18.26'
  
     testImplementation ('com.jayway.jsonpath:json-path:2.7.0') {
         exclude group: "org.ow2.asm", module: "asm"

--- a/fahrschein/build.gradle
+++ b/fahrschein/build.gradle
@@ -12,11 +12,6 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-annotations:${property('jackson.version')}"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${property('jackson.version')}"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${property('jackson.version')}"
-    compileOnly 'org.projectlombok:lombok:1.18.26'
-    annotationProcessor 'org.projectlombok:lombok:1.18.26'
-
-    testCompileOnly 'org.projectlombok:lombok:1.18.26'
-    testAnnotationProcessor 'org.projectlombok:lombok:1.18.26'
  
     testImplementation ('com.jayway.jsonpath:json-path:2.7.0') {
         exclude group: "org.ow2.asm", module: "asm"

--- a/fahrschein/src/main/java/org/zalando/fahrschein/PlatformAccessTokenProvider.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/PlatformAccessTokenProvider.java
@@ -1,14 +1,9 @@
 package org.zalando.fahrschein;
 
-import lombok.AllArgsConstructor;
-import org.zalando.fahrschein.AccessTokenProvider;
-import org.zalando.fahrschein.Preconditions;
-
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.List;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -26,7 +21,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  *
  * @see <a href="https://kubernetes-on-aws.readthedocs.io/en/latest/user-guide/zalando-iam.html">Zalando Platform IAM Integration</a>
  */
-@AllArgsConstructor
 public class PlatformAccessTokenProvider implements AccessTokenProvider {
 
     private static final String TOKEN_SECRET_SUFFIX = "-token-secret";
@@ -35,23 +29,28 @@ public class PlatformAccessTokenProvider implements AccessTokenProvider {
 
     private static final String DEFAULT_APPLICATION_NAME = "nakadi";
 
-    private final String directory;
+    private final Path directory;
 
     private final String name;
 
+    public PlatformAccessTokenProvider(final Path directory, final String name) {
+        this.directory = directory;
+        this.name = name;
+    }
+
     public PlatformAccessTokenProvider() {
-        this(DEFAULT_CREDENTIALS_DIRECTORY, DEFAULT_APPLICATION_NAME);
+        this(Paths.get(DEFAULT_CREDENTIALS_DIRECTORY), DEFAULT_APPLICATION_NAME);
     }
 
     public PlatformAccessTokenProvider(final String name) {
-        this(DEFAULT_CREDENTIALS_DIRECTORY, name);
+        this(Paths.get(DEFAULT_CREDENTIALS_DIRECTORY), name);
     }
 
     @Override
     public String getAccessToken() throws IOException {
-        final Path filePath = Paths.get(this.directory, name + TOKEN_SECRET_SUFFIX);
-        final List<String> lines = Files.readAllLines(filePath, UTF_8);
-        Preconditions.checkArgument(!lines.isEmpty(), "Secret file cannot be empty");
-        return Files.readAllLines(filePath, UTF_8).get(0);
+        final Path filePath = this.directory.resolve(name + TOKEN_SECRET_SUFFIX);
+        final String token = new String(Files.readAllBytes(filePath), UTF_8);
+        Preconditions.checkArgument(token.length() != 0, "Secret file cannot be empty");
+        return token;
     }
 }

--- a/fahrschein/src/main/java/org/zalando/fahrschein/PlatformAccessTokenProvider.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/PlatformAccessTokenProvider.java
@@ -1,4 +1,4 @@
-package org.zalando.fahrschein.domain;
+package org.zalando.fahrschein;
 
 import lombok.AllArgsConstructor;
 import org.zalando.fahrschein.AccessTokenProvider;

--- a/fahrschein/src/main/java/org/zalando/fahrschein/ZignAccessTokenProvider.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/ZignAccessTokenProvider.java
@@ -16,7 +16,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 
 /**
- * @deprecated  As of release 1.0, replaced by {@link  org.zalando.fahrschein.domain.PlatformAccessTokenProvider}
+ * @deprecated  As of release 1.0, replaced by {@link  PlatformAccessTokenProvider}
  */
 @Deprecated
 public class ZignAccessTokenProvider implements AccessTokenProvider {

--- a/fahrschein/src/main/java/org/zalando/fahrschein/ZignAccessTokenProvider.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/ZignAccessTokenProvider.java
@@ -14,6 +14,11 @@ import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+
+/**
+ * @deprecated  As of release 1.0, replaced by {@link  org.zalando.fahrschein.domain.PlatformAccessTokenProvider}
+ */
+@Deprecated
 public class ZignAccessTokenProvider implements AccessTokenProvider {
     private static final Logger LOG = LoggerFactory.getLogger(ZignAccessTokenProvider.class);
     private static final long CACHE_DURATION = 5 * 60 * 1000L;

--- a/fahrschein/src/main/java/org/zalando/fahrschein/domain/PlatformAccessTokenProvider.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/domain/PlatformAccessTokenProvider.java
@@ -1,0 +1,57 @@
+package org.zalando.fahrschein.domain;
+
+import lombok.AllArgsConstructor;
+import org.zalando.fahrschein.AccessTokenProvider;
+import org.zalando.fahrschein.Preconditions;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+/**
+ * Default {@link AccessTokenProvider access token provider} built for Zalando's Platform IAM which provides
+ * OAuth2 tokens as files in a mounted directory. Each token is represented as a set of two individual files:
+ *
+ * <dl>
+ *     <dt>{name}-token-type</dt>
+ *     <dd>Contains the token type, e.g. Bearer.</dd>
+ *
+ *     <dt>{name}-token-secret</dt>
+ *     <dd>Contains the actual secret, e.g. a Json Web Token (JWT)</dd>
+ * </dl>
+ *
+ * @see <a href="https://kubernetes-on-aws.readthedocs.io/en/latest/user-guide/zalando-iam.html">Zalando Platform IAM Integration</a>
+ */
+@AllArgsConstructor
+public class PlatformAccessTokenProvider implements AccessTokenProvider {
+
+    private static final String TOKEN_SECRET_SUFFIX = "-token-secret";
+
+    private static final String DEFAULT_CREDENTIALS_DIRECTORY = "/meta/credentials";
+
+    private static final String DEFAULT_APPLICATION_NAME = "nakadi";
+
+    private final String directory;
+
+    private final String name;
+
+    public PlatformAccessTokenProvider() {
+        this(DEFAULT_CREDENTIALS_DIRECTORY, DEFAULT_APPLICATION_NAME);
+    }
+
+    public PlatformAccessTokenProvider(final String name) {
+        this(DEFAULT_CREDENTIALS_DIRECTORY, name);
+    }
+
+    @Override
+    public String getAccessToken() throws IOException {
+        final Path filePath = Paths.get(this.directory, name + TOKEN_SECRET_SUFFIX);
+        final List<String> lines = Files.readAllLines(filePath, UTF_8);
+        Preconditions.checkArgument(!lines.isEmpty(), "Secret file cannot be empty");
+        return Files.readAllLines(filePath, UTF_8).get(0);
+    }
+}

--- a/fahrschein/src/test/java/org/zalando/fahrschein/PlatformAccessTokenProviderTest.java
+++ b/fahrschein/src/test/java/org/zalando/fahrschein/PlatformAccessTokenProviderTest.java
@@ -1,0 +1,31 @@
+package org.zalando.fahrschein;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.zalando.fahrschein.domain.PlatformAccessTokenProvider;
+
+import java.io.IOException;
+
+public class PlatformAccessTokenProviderTest {
+
+    @Test
+    public void shouldLoadAuthorizationToken() throws IOException {
+        final PlatformAccessTokenProvider tokenProvider = new PlatformAccessTokenProvider("./src/test/resources/meta/credentials", "nakadi");
+        final String[] tokenWithType = tokenProvider.getAuthorizationHeader().split(" ");
+        Assertions.assertNotNull(tokenWithType);
+        Assertions.assertEquals("Bearer", tokenWithType[0]);
+        Assertions.assertEquals("some-secret-token", tokenWithType[1]);
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenFileDoesntExist() {
+        final PlatformAccessTokenProvider tokenProvider = new PlatformAccessTokenProvider("./src/test/resources/meta/credentials", "dummy");
+        Assertions.assertThrows(IOException.class, tokenProvider::getAuthorizationHeader);
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenSecretFileIsEmpty() {
+        final PlatformAccessTokenProvider tokenProvider = new PlatformAccessTokenProvider("./src/test/resources/meta/credentials", "empty");
+        Assertions.assertThrows(IllegalArgumentException.class, tokenProvider::getAuthorizationHeader);
+    }
+}

--- a/fahrschein/src/test/java/org/zalando/fahrschein/PlatformAccessTokenProviderTest.java
+++ b/fahrschein/src/test/java/org/zalando/fahrschein/PlatformAccessTokenProviderTest.java
@@ -2,7 +2,6 @@ package org.zalando.fahrschein;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.zalando.fahrschein.domain.PlatformAccessTokenProvider;
 
 import java.io.IOException;
 

--- a/fahrschein/src/test/java/org/zalando/fahrschein/PlatformAccessTokenProviderTest.java
+++ b/fahrschein/src/test/java/org/zalando/fahrschein/PlatformAccessTokenProviderTest.java
@@ -4,12 +4,13 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.nio.file.Paths;
 
 public class PlatformAccessTokenProviderTest {
 
     @Test
     public void shouldLoadAuthorizationToken() throws IOException {
-        final PlatformAccessTokenProvider tokenProvider = new PlatformAccessTokenProvider("./src/test/resources/meta/credentials", "nakadi");
+        final PlatformAccessTokenProvider tokenProvider = new PlatformAccessTokenProvider(Paths.get("./src/test/resources/meta/credentials"), "nakadi");
         final String[] tokenWithType = tokenProvider.getAuthorizationHeader().split(" ");
         Assertions.assertNotNull(tokenWithType);
         Assertions.assertEquals("Bearer", tokenWithType[0]);
@@ -18,13 +19,13 @@ public class PlatformAccessTokenProviderTest {
 
     @Test
     public void shouldThrowExceptionWhenFileDoesntExist() {
-        final PlatformAccessTokenProvider tokenProvider = new PlatformAccessTokenProvider("./src/test/resources/meta/credentials", "dummy");
+        final PlatformAccessTokenProvider tokenProvider = new PlatformAccessTokenProvider(Paths.get("./src/test/resources/meta/credentials"), "dummy");
         Assertions.assertThrows(IOException.class, tokenProvider::getAuthorizationHeader);
     }
 
     @Test
     public void shouldThrowExceptionWhenSecretFileIsEmpty() {
-        final PlatformAccessTokenProvider tokenProvider = new PlatformAccessTokenProvider("./src/test/resources/meta/credentials", "empty");
+        final PlatformAccessTokenProvider tokenProvider = new PlatformAccessTokenProvider(Paths.get("./src/test/resources/meta/credentials"), "empty");
         Assertions.assertThrows(IllegalArgumentException.class, tokenProvider::getAuthorizationHeader);
     }
 }

--- a/fahrschein/src/test/resources/meta/credentials/nakadi-token-secret
+++ b/fahrschein/src/test/resources/meta/credentials/nakadi-token-secret
@@ -1,0 +1,1 @@
+some-secret-token


### PR DESCRIPTION
Our default authorization provider `ZignAccessTokenProvider.java` is outdated and the usage of zign is not recomended anymore by default. 
 
In this PR I have introduced support for [Zalando's platform IAM](https://kubernetes-on-aws.readthedocs.io/en/latest/user-guide/zalando-iam.html) and we could replace `ZignAccessTokenProvider` with this new integration. 

See #381 