### PR TITLE
WIP Reverse after and error handler calls

### DIFF
--- a/fahrschein-opentelemetry/src/main/java/org/zalando/fahrschein/opentelemetry/InstrumentedPublishingHandler.java
+++ b/fahrschein-opentelemetry/src/main/java/org/zalando/fahrschein/opentelemetry/InstrumentedPublishingHandler.java
@@ -42,7 +42,7 @@ public class InstrumentedPublishingHandler implements EventPublishingHandler {
 
     @Override
     public <T> void onError(List<T> events, Throwable t) {
-        Span.current().setStatus(StatusCode.ERROR).recordException(t).end();
+        Span.current().setStatus(StatusCode.ERROR).recordException(t);
     }
 
     // changes must be applied to both OpenTracing and OpenTelemetry implementations.

--- a/fahrschein-opentelemetry/src/main/java/org/zalando/fahrschein/opentelemetry/InstrumentedPublishingHandler.java
+++ b/fahrschein-opentelemetry/src/main/java/org/zalando/fahrschein/opentelemetry/InstrumentedPublishingHandler.java
@@ -4,6 +4,8 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.zalando.fahrschein.EventPublishingHandler;
 
 import java.util.List;
@@ -16,6 +18,9 @@ import static io.opentelemetry.api.trace.SpanKind.PRODUCER;
  */
 public class InstrumentedPublishingHandler implements EventPublishingHandler {
 
+
+    private static final Logger LOG = LoggerFactory.getLogger(InstrumentedPublishingHandler.class);
+
     private final Tracer tracer;
 
     public InstrumentedPublishingHandler(Tracer tracer) {
@@ -24,25 +29,37 @@ public class InstrumentedPublishingHandler implements EventPublishingHandler {
 
     @Override
     public <T> void onPublish(String eventName, List<T> events) {
-        Span span = tracer
-                .spanBuilder("send_" + eventName)
-                .setParent(Context.current())
-                .setSpanKind(PRODUCER)
-                .setAttribute("messaging.destination_kind", "topic")
-                .setAttribute("messaging.destination", eventName)
-                .setAttribute("messaging.system", "Nakadi")
-                .setAttribute("messaging.message_payload_size", sizeBucket(events.size()))
-                .startSpan();
-        span.makeCurrent();
+        try {
+            Span span = tracer
+                    .spanBuilder("send_" + eventName)
+                    .setParent(Context.current())
+                    .setSpanKind(PRODUCER)
+                    .setAttribute("messaging.destination_kind", "topic")
+                    .setAttribute("messaging.destination", eventName)
+                    .setAttribute("messaging.system", "Nakadi")
+                    .setAttribute("messaging.message_payload_size", sizeBucket(events.size()))
+                    .startSpan();
+            span.makeCurrent();
+        } catch (Exception e) {
+            LOG.error("Exception during onPublish handling", e);
+        }
     }
 
     public void afterPublish() {
-        Span.current().end();
+        try {
+            Span.current().end();
+        } catch (Exception e) {
+            LOG.error("Exception during afterPublish handling", e);
+        }
     }
 
     @Override
     public <T> void onError(List<T> events, Throwable t) {
-        Span.current().setStatus(StatusCode.ERROR).recordException(t);
+        try {
+            Span.current().setStatus(StatusCode.ERROR).recordException(t);
+        } catch (Exception e) {
+            LOG.error("Exception during onError handling", e);
+        }
     }
 
     // changes must be applied to both OpenTracing and OpenTelemetry implementations.

--- a/fahrschein-opentelemetry/src/test/java/org/zalando/fahrschein/opentelemetry/InstrumentedPublishingHandlerTest.java
+++ b/fahrschein-opentelemetry/src/test/java/org/zalando/fahrschein/opentelemetry/InstrumentedPublishingHandlerTest.java
@@ -62,6 +62,7 @@ class InstrumentedPublishingHandlerTest {
             // when
             instrumentedHandler.onPublish("test_event", Arrays.asList("ev1", "ev2"));
             instrumentedHandler.onError(Arrays.asList("ev1", "ev2"), somethingIsWrong);
+            instrumentedHandler.afterPublish();
 
             // then
             otelTesting.assertTraces()

--- a/fahrschein-opentracing/src/main/java/org/zalando/fahrschein/opentracing/InstrumentedPublishingHandler.java
+++ b/fahrschein-opentracing/src/main/java/org/zalando/fahrschein/opentracing/InstrumentedPublishingHandler.java
@@ -44,7 +44,6 @@ public class InstrumentedPublishingHandler implements EventPublishingHandler {
     @Override
     public <T> void onError(List<T> events, Throwable t) {
         tracer.activeSpan().setTag(ERROR, true);
-        tracer.activeSpan().finish();
     }
 
     // changes must be applied to both OpenTracing and OpenTelemetry implementations.

--- a/fahrschein-opentracing/src/main/java/org/zalando/fahrschein/opentracing/InstrumentedPublishingHandler.java
+++ b/fahrschein-opentracing/src/main/java/org/zalando/fahrschein/opentracing/InstrumentedPublishingHandler.java
@@ -3,6 +3,8 @@ package org.zalando.fahrschein.opentracing;
 import io.opentracing.Span;
 import io.opentracing.Tracer;
 import io.opentracing.tag.Tags;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.zalando.fahrschein.EventPublishingHandler;
 
 import java.util.List;
@@ -12,6 +14,8 @@ import static io.opentracing.tag.Tags.ERROR;
 
 public class InstrumentedPublishingHandler implements EventPublishingHandler {
 
+    private static final Logger LOG = LoggerFactory.getLogger(InstrumentedPublishingHandler.class);
+
     private final Tracer tracer;
 
     public InstrumentedPublishingHandler(Tracer tracer) {
@@ -20,30 +24,43 @@ public class InstrumentedPublishingHandler implements EventPublishingHandler {
 
     @Override
     public <T> void onPublish(String eventName, List<T> events) {
-        Span start = tracer.buildSpan("send_" + eventName)
-                .asChildOf(tracer.activeSpan())
-                .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_PRODUCER)
-                .withTag("messaging.destination_kind", "topic")
-                // note that OpenTracing actually defines "message_bus.destination" but we stick to the
-                // semantic naming conventions of OpenTelemetry for consistency across services.
-                .withTag("messaging.destination", eventName)
-                // message payload size in number of entities, of a given messaging operation (producing or consuming).
-                // The value should be in buckets (e.g.: 1-10). Based on internal guidance for tracing of messaging systems
-                .withTag("messaging.message_payload_size", sizeBucket(events.size()))
-                .withTag("messaging.system", "Nakadi")
-                .start();
+        try {
+            Span start = tracer.buildSpan("send_" + eventName)
+                    .asChildOf(tracer.activeSpan())
+                    .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_PRODUCER)
+                    .withTag("messaging.destination_kind", "topic")
+                    // note that OpenTracing actually defines "message_bus.destination" but we stick to the
+                    // semantic naming conventions of OpenTelemetry for consistency across services.
+                    .withTag("messaging.destination", eventName)
+                    // message payload size in number of entities, of a given messaging operation (producing or consuming).
+                    // The value should be in buckets (e.g.: 1-10). Based on internal guidance for tracing of messaging systems
+                    .withTag("messaging.message_payload_size", sizeBucket(events.size()))
+                    .withTag("messaging.system", "Nakadi")
+                    .start();
 
-        tracer.activateSpan(start);
+            tracer.activateSpan(start);
+        } catch (Exception e) {
+            LOG.error("Exception during onPublish handling", e);
+        }
     }
 
     @Override
     public void afterPublish() {
-        tracer.activeSpan().finish();
+        try {
+            tracer.activeSpan().finish();
+        } catch (Exception e) {
+            LOG.error("Exception during afterPublish handling", e);
+        }
     }
 
     @Override
     public <T> void onError(List<T> events, Throwable t) {
-        tracer.activeSpan().setTag(ERROR, true);
+        try {
+            tracer.activeSpan().setTag(ERROR, true);
+            tracer.activeSpan().setTag("message", t.getMessage());
+        } catch (Exception e) {
+            LOG.error("Exception during onError handling", e);
+        }
     }
 
     // changes must be applied to both OpenTracing and OpenTelemetry implementations.

--- a/fahrschein-opentracing/src/test/java/org/zalando/fahrschein/opentracing/InstrumentedPublishingHandlerTest.java
+++ b/fahrschein-opentracing/src/test/java/org/zalando/fahrschein/opentracing/InstrumentedPublishingHandlerTest.java
@@ -57,6 +57,7 @@ class InstrumentedPublishingHandlerTest {
         // when
         instrumentedPublishingHandler.onPublish("test_event", Arrays.asList("ev1", "ev2"));
         instrumentedPublishingHandler.onError(Arrays.asList("ev1", "ev2"), somethingWentWrong);
+        instrumentedPublishingHandler.afterPublish();
 
         // then
         assertEquals(1, tracer.finishedSpans().size(), "finished spans");

--- a/fahrschein/src/main/java/org/zalando/fahrschein/EventPublishingHandler.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/EventPublishingHandler.java
@@ -22,14 +22,13 @@ public interface EventPublishingHandler {
 
     /**
      * This method is invoked after the publishing of events has happened,
-     * but only if the publishing didn't face an Exception otherwise
-     * onError will be invoked.
+     * regardless if an error occurred during publishing or not.
      *
      */
     void afterPublish();
 
     /**
-     * Invoked when publishing of events failed.
+     * Invoked when publishing of events failed, before afterPublish.
      *
      * @param events original list of events that we tried to publish
      * @param t the throwable we experienced while publishing

--- a/fahrschein/src/main/java/org/zalando/fahrschein/EventPublishingHandler.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/EventPublishingHandler.java
@@ -14,6 +14,9 @@ public interface EventPublishingHandler {
      * This method is called by the {@code NakadiClient} when a request towards Nakadi is going to be sent.
      * For example, it can be used to record things before that.
      *
+     * Every {@code EventPublishingHandler} implementation is responsible for catching and logging exceptions
+     * happening in this method.
+     *
      * @param eventName that is used for the published events
      * @param events that are published
      * @param <T> type of events that we publish
@@ -24,11 +27,17 @@ public interface EventPublishingHandler {
      * This method is invoked after the publishing of events has happened,
      * regardless if an error occurred during publishing or not.
      *
+     * Every {@code EventPublishingHandler} implementation is responsible for catching and logging exceptions
+     * happening in this method.
+     *
      */
     void afterPublish();
 
     /**
      * Invoked when publishing of events failed, before afterPublish.
+     *
+     * Every {@code EventPublishingHandler} implementation is responsible for catching and logging exceptions
+     * happening in this method.
      *
      * @param events original list of events that we tried to publish
      * @param t the throwable we experienced while publishing

--- a/fahrschein/src/main/java/org/zalando/fahrschein/NakadiClient.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/NakadiClient.java
@@ -120,13 +120,7 @@ public class NakadiClient {
             if(response != null) {
                 response.close();
             }
-            eventPublishingHandlers.descendingIterator().forEachRemaining(handler -> {
-                try {
-                    handler.afterPublish();
-                } catch (Exception e) {
-                    LOG.warn("Exception occurred during callbacks to eventPublishingHandlers", e);
-                }
-            });
+            eventPublishingHandlers.descendingIterator().forEachRemaining(handler -> handler.afterPublish());
         }
     }
 


### PR DESCRIPTION
So that event publishing handlers do not interact with one another unexpectedly.

## Changes

- Event publishing handlers are called in reverse order onError and afterPublish
- afterPublish is always called regardless of error (finally block) 
- every handler's afterPublish is ensured to be called by adding individual try-catch blocks
- API docs updated

