### PR TITLE
Suppress CVE-2023-20860

### DIFF
--- a/cve-suppressions.xml
+++ b/cve-suppressions.xml
@@ -2,6 +2,12 @@
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
 <suppress>
    <notes><![CDATA[
+	   This vulnerability only applies to using Spring Web as Server application.
+   ]]></notes>
+   <cve>CVE-2023-20860</cve>
+</suppress>
+<suppress>
+   <notes><![CDATA[
 	   This vulnerablility is not going to be fixed by Spring. Instead, it's an inherent insecurity of
 	   Java Serialization, and the advice is not to rely on Java Serialization for untrusted data.
    ]]></notes>


### PR DESCRIPTION
Suppress CVE-2023-20860. It doesn't apply to Fahrschein, which is using spring-web as client library.