### PR TITLE
False positive: CVE-2023-35116

### DIFF
--- a/cve-suppressions.xml
+++ b/cve-suppressions.xml
@@ -31,4 +31,11 @@
    ]]></notes>
    <cve>CVE-2022-45688</cve>
 </suppress>
+<suppress>
+   <notes><![CDATA[
+   This CVE is a false positive according to the Jackson project maintainers.
+   See https://github.com/FasterXML/jackson-databind/issues/3972
+   ]]></notes>
+   <cve>CVE-2023-35116</cve>
+</suppress>
 </suppressions>


### PR DESCRIPTION
CVE-2023-35116 is filed as false positive, according to the Jackson project maintainers. 
See https://github.com/FasterXML/jackson-databind/issues/3972

