### PR TITLE
Trim auth token

### DIFF
--- a/fahrschein/src/main/java/org/zalando/fahrschein/PlatformAccessTokenProvider.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/PlatformAccessTokenProvider.java
@@ -51,6 +51,6 @@ public class PlatformAccessTokenProvider implements AccessTokenProvider {
         final Path filePath = this.directory.resolve(name + TOKEN_SECRET_SUFFIX);
         final String token = new String(Files.readAllBytes(filePath), UTF_8);
         Preconditions.checkArgument(token.length() != 0, "Secret file cannot be empty");
-        return token;
+        return token.trim();
     }
 }

--- a/fahrschein/src/test/java/org/zalando/fahrschein/PlatformAccessTokenProviderTest.java
+++ b/fahrschein/src/test/java/org/zalando/fahrschein/PlatformAccessTokenProviderTest.java
@@ -6,15 +6,18 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.nio.file.Paths;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 public class PlatformAccessTokenProviderTest {
 
     @Test
     public void shouldLoadAuthorizationToken() throws IOException {
         final PlatformAccessTokenProvider tokenProvider = new PlatformAccessTokenProvider(Paths.get("./src/test/resources/meta/credentials"), "nakadi");
         final String[] tokenWithType = tokenProvider.getAuthorizationHeader().split(" ");
-        Assertions.assertNotNull(tokenWithType);
-        Assertions.assertEquals("Bearer", tokenWithType[0]);
-        Assertions.assertEquals("some-secret-token", tokenWithType[1]);
+        assertNotNull(tokenWithType);
+        assertEquals("Bearer", tokenWithType[0]);
+        assertEquals("some-secret-token", tokenWithType[1]);
     }
 
     @Test
@@ -33,8 +36,8 @@ public class PlatformAccessTokenProviderTest {
     public void shouldTrimAuthorizationToken() throws IOException {
         final PlatformAccessTokenProvider tokenProvider = new PlatformAccessTokenProvider(Paths.get("./src/test/resources/meta/credentials"), "whitespace-newline");
         final String[] tokenWithType = tokenProvider.getAuthorizationHeader().split(" ");
-        Assertions.assertNotNull(tokenWithType);
-        Assertions.assertEquals("Bearer", tokenWithType[0]);
-        Assertions.assertEquals("some-secret-token", tokenWithType[1]);
+        assertNotNull(tokenWithType);
+        assertEquals("Bearer", tokenWithType[0]);
+        assertEquals("some-secret-token", tokenWithType[1]);
     }
 }

--- a/fahrschein/src/test/java/org/zalando/fahrschein/PlatformAccessTokenProviderTest.java
+++ b/fahrschein/src/test/java/org/zalando/fahrschein/PlatformAccessTokenProviderTest.java
@@ -28,4 +28,13 @@ public class PlatformAccessTokenProviderTest {
         final PlatformAccessTokenProvider tokenProvider = new PlatformAccessTokenProvider(Paths.get("./src/test/resources/meta/credentials"), "empty");
         Assertions.assertThrows(IllegalArgumentException.class, tokenProvider::getAuthorizationHeader);
     }
+
+    @Test
+    public void shouldTrimAuthorizationToken() throws IOException {
+        final PlatformAccessTokenProvider tokenProvider = new PlatformAccessTokenProvider(Paths.get("./src/test/resources/meta/credentials"), "whitespace-newline");
+        final String[] tokenWithType = tokenProvider.getAuthorizationHeader().split(" ");
+        Assertions.assertNotNull(tokenWithType);
+        Assertions.assertEquals("Bearer", tokenWithType[0]);
+        Assertions.assertEquals("some-secret-token", tokenWithType[1]);
+    }
 }

--- a/fahrschein/src/test/resources/meta/credentials/whitespace-newline-token-secret
+++ b/fahrschein/src/test/resources/meta/credentials/whitespace-newline-token-secret
@@ -1,0 +1,2 @@
+ some-secret-token
+


### PR DESCRIPTION
Trim the authorization token to remove all leading and trailing whitespaces and new line characters from the token.

Closes https://github.com/zalando-nakadi/fahrschein/issues/398

