### PR TITLE
Upgrade Spring dependencies and jdk target

### DIFF
--- a/fahrschein-http-jdk11/build.gradle
+++ b/fahrschein-http-jdk11/build.gradle
@@ -8,8 +8,4 @@ dependencies {
     testImplementation(testFixtures(project(':fahrschein-http-test-support')))
 }
 
-tasks.withType(JavaCompile).configureEach {
-    options.release = Math.max(Integer.valueOf(project.property("jdk.version")), 11)
-}
-
 publishing.publications.maven.pom.description = "Fahrschein HTTP Client using JDK11's HttpClient"

--- a/fahrschein-http-spring/build.gradle
+++ b/fahrschein-http-spring/build.gradle
@@ -14,7 +14,3 @@ dependencies {
 }
 
 publishing.publications.maven.pom.description = 'Fahrschein HTTP Client using Spring Adapter'
-
-tasks.withType(JavaCompile).configureEach {
-    options.release = 17
-}

--- a/fahrschein-http-spring/build.gradle
+++ b/fahrschein-http-spring/build.gradle
@@ -14,3 +14,4 @@ dependencies {
 }
 
 publishing.publications.maven.pom.description = 'Fahrschein HTTP Client using Spring Adapter'
+

--- a/fahrschein-http-spring/build.gradle
+++ b/fahrschein-http-spring/build.gradle
@@ -14,3 +14,7 @@ dependencies {
 }
 
 publishing.publications.maven.pom.description = 'Fahrschein HTTP Client using Spring Adapter'
+
+tasks.withType(JavaCompile).configureEach {
+    options.release = 17
+}

--- a/fahrschein-spring-boot-starter/build.gradle
+++ b/fahrschein-spring-boot-starter/build.gradle
@@ -36,7 +36,3 @@ configurations {
 test {
     useJUnitPlatform()
 }
-
-tasks.withType(JavaCompile).configureEach {
-    options.release = 17
-}

--- a/fahrschein-spring-boot-starter/build.gradle
+++ b/fahrschein-spring-boot-starter/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'fahrschein.java-conventions'
     id 'fahrschein.maven-publishing-conventions'
-    id 'org.springframework.boot' version '2.6.6' apply false
+    id 'org.springframework.boot' version '3.1.1' apply false
     id 'io.spring.dependency-management' version '1.0.11.RELEASE' apply false
 }
 

--- a/fahrschein-spring-boot-starter/build.gradle
+++ b/fahrschein-spring-boot-starter/build.gradle
@@ -1,8 +1,6 @@
 plugins {
     id 'fahrschein.java-conventions'
     id 'fahrschein.maven-publishing-conventions'
-    id 'org.springframework.boot' version '3.1.1' apply false
-    id 'io.spring.dependency-management' version '1.0.11.RELEASE' apply false
 }
 
 def lombok_version = '1.18.28'
@@ -15,11 +13,11 @@ dependencies {
     implementation "com.fasterxml.jackson.module:jackson-module-parameter-names:${property('jackson.version')}"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${property('jackson.version')}"
     implementation 'com.google.guava:guava:31.0.1-jre'
-    compileOnly "org.springframework.boot:spring-boot-configuration-processor:${property('springboot.version')}"
+    compileOnlyApi "org.springframework.boot:spring-boot-configuration-processor:${property('springboot.version')}"
     compileOnly 'io.micrometer:micrometer-core:1.8.4'
     compileOnly "org.projectlombok:lombok:${lombok_version}"
     annotationProcessor "org.projectlombok:lombok:${lombok_version}"
-    compileOnly "org.springframework.boot:spring-boot-autoconfigure:${property('springboot.version')}"
+    compileOnlyApi "org.springframework.boot:spring-boot-autoconfigure:${property('springboot.version')}"
     testAnnotationProcessor "org.projectlombok:lombok:${lombok_version}"
     testImplementation 'io.micrometer:micrometer-core:1.8.4'
     testImplementation "org.projectlombok:lombok:${lombok_version}"
@@ -35,4 +33,8 @@ configurations {
 
 test {
     useJUnitPlatform()
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.release = 17
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,4 +16,4 @@ opentelemetry.version=1.20.1
 opentracing.version=0.33.0
 
 ## target JDK release version
-jdk.version=8
+jdk.version=17

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ project.version=2.0.0-RC-1
 jackson.version=2.14.1
 jackson_databind.version=2.14.1
 slf4j.version=1.7.25
-spring.version=6.0.11
+spring.version=5.3.20
 springboot.version=3.1.1
 mockito.version=4.9.0
 junit.version=5.9.1
@@ -16,4 +16,4 @@ opentelemetry.version=1.20.1
 opentracing.version=0.33.0
 
 ## target JDK release version
-jdk.version=17
+jdk.version=11

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 ## project version
-project.version=2.0.0-RC-1
+project.version=2.0.0-RC1
 
 ## dependency versions
 jackson.version=2.14.1
@@ -16,4 +16,4 @@ opentelemetry.version=1.20.1
 opentracing.version=0.33.0
 
 ## target JDK release version
-jdk.version=11
+jdk.version=17

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,4 +16,4 @@ opentelemetry.version=1.20.1
 opentracing.version=0.33.0
 
 ## target JDK release version
-jdk.version=17
+jdk.version=8

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 ## project version
-project.version=2.0.0
+project.version=2.0.0-SNAPSHOT
 
 ## dependency versions
 jackson.version=2.14.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 ## project version
-project.version=1.0.0
+project.version=2.0.0
 
 ## dependency versions
 jackson.version=2.14.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 ## project version
-project.version=2.0.0-SNAPSHOT
+project.version=2.0.0-RC-1
 
 ## dependency versions
 jackson.version=2.14.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,8 +5,8 @@ project.version=1.0.0
 jackson.version=2.14.1
 jackson_databind.version=2.14.1
 slf4j.version=1.7.25
-spring.version=5.3.20
-springboot.version=2.6.6
+spring.version=6.0.11
+springboot.version=3.1.1
 mockito.version=4.9.0
 junit.version=5.9.1
 testcontainers.version=1.17.6
@@ -16,4 +16,4 @@ opentelemetry.version=1.20.1
 opentracing.version=0.33.0
 
 ## target JDK release version
-jdk.version=8
+jdk.version=17


### PR DESCRIPTION
Upgrade to Spring6 and Spring Boot 3.

Thus, we decided to upgrade the JDK target to java17 for the whole project, which justifies a 2.0.0 release.

## Changes

- Bumps baseline JDK to 17
- Sets default dependency for spring framework to 6
- Sets default dependency for spring-boot to 3
- Bumps the version to 2.0.0-RC1

## TODO

- [ ] Mention JDK17 requirement in README
- [ ] Mention Spring version dependencies in README
