### PR TITLE
Remove guava from spring-boot-starter

### DIFF
--- a/fahrschein-spring-boot-starter/build.gradle
+++ b/fahrschein-spring-boot-starter/build.gradle
@@ -12,7 +12,6 @@ dependencies {
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${property('jackson.version')}"
     implementation "com.fasterxml.jackson.module:jackson-module-parameter-names:${property('jackson.version')}"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${property('jackson.version')}"
-    implementation 'com.google.guava:guava:32.1.2-jre'
     compileOnlyApi "org.springframework.boot:spring-boot-configuration-processor:${property('springboot.version')}"
     implementation 'io.micrometer:micrometer-core:1.11.2'
     compileOnly "org.projectlombok:lombok:${lombok_version}"

--- a/fahrschein-spring-boot-starter/src/main/java/org/zalando/spring/boot/fahrschein/config/Ratio.java
+++ b/fahrschein-spring-boot-starter/src/main/java/org/zalando/spring/boot/fahrschein/config/Ratio.java
@@ -8,7 +8,7 @@ import java.util.function.BiConsumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static com.google.common.base.Preconditions.checkArgument;
+import static org.zalando.fahrschein.Preconditions.checkArgument;
 
 @AllArgsConstructor
 @Getter

--- a/fahrschein-spring-boot-starter/src/main/java/org/zalando/spring/boot/fahrschein/config/Registry.java
+++ b/fahrschein-spring-boot-starter/src/main/java/org/zalando/spring/boot/fahrschein/config/Registry.java
@@ -16,11 +16,10 @@ import org.zalando.spring.boot.fahrschein.nakadi.stereotype.NakadiEventListener;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
-import static com.google.common.base.CaseFormat.LOWER_CAMEL;
-import static com.google.common.base.CaseFormat.LOWER_HYPHEN;
-import static com.google.common.base.CaseFormat.UPPER_CAMEL;
 import static org.springframework.beans.factory.support.BeanDefinitionBuilder.genericBeanDefinition;
 
 public class Registry {
@@ -86,11 +85,18 @@ public class Registry {
     }
 
     public static <T> String generateBeanName(final Class<T> type) {
-        return UPPER_CAMEL.to(LOWER_CAMEL, type.getSimpleName());
+        // convert from upper camel to lower camel case.
+        String input = type.getSimpleName();
+        char firstChar = Character.toLowerCase(input.charAt(0));
+        return firstChar + input.substring(1);
     }
 
     public static <T> String generateBeanName(final String id, final Class<T> type) {
-        return LOWER_HYPHEN.to(LOWER_CAMEL, id) + type.getSimpleName();
+        // convert from lower hyphen to lower camel case.
+        List<String> parts = Arrays.asList(id.split("-"));
+        return parts.get(0) + parts.subList(1, parts.size()).stream()
+                .map(s -> s.isEmpty() ? "" : s.substring(0, 1).toUpperCase(Locale.ENGLISH) + s.substring(1).toLowerCase(Locale.ENGLISH))
+                .collect(Collectors.joining()) + type.getSimpleName();
     }
 
     public static BeanReference ref(final String beanName) {

--- a/fahrschein-spring-boot-starter/src/main/java/org/zalando/spring/boot/fahrschein/config/TimeSpan.java
+++ b/fahrschein-spring-boot-starter/src/main/java/org/zalando/spring/boot/fahrschein/config/TimeSpan.java
@@ -12,9 +12,9 @@ import java.util.function.BiConsumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
+import static org.zalando.fahrschein.Preconditions.checkArgument;
 
 @AllArgsConstructor(staticName = "of")
 @Getter

--- a/fahrschein-spring-boot-starter/src/main/java/org/zalando/spring/boot/fahrschein/nakadi/config/NakadiClientsPostProcessor.java
+++ b/fahrschein-spring-boot-starter/src/main/java/org/zalando/spring/boot/fahrschein/nakadi/config/NakadiClientsPostProcessor.java
@@ -1,6 +1,5 @@
 package org.zalando.spring.boot.fahrschein.nakadi.config;
 
-import com.google.common.collect.Lists;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
@@ -13,9 +12,9 @@ import org.zalando.spring.boot.fahrschein.config.Registry;
 import org.zalando.spring.boot.fahrschein.nakadi.config.properties.FahrscheinConfigProperties;
 import org.zalando.spring.boot.fahrschein.nakadi.config.properties.SettingsParser;
 
-import java.util.Collection;
 import java.util.NoSuchElementException;
 import java.util.ServiceLoader;
+import java.util.stream.StreamSupport;
 
 @RequiredArgsConstructor
 public class NakadiClientsPostProcessor implements BeanDefinitionRegistryPostProcessor, EnvironmentAware {
@@ -24,14 +23,14 @@ public class NakadiClientsPostProcessor implements BeanDefinitionRegistryPostPro
 
     @Override
     public void setEnvironment(Environment environment) {
-        final Collection<SettingsParser> parsers = Lists.newArrayList(ServiceLoader.load(SettingsParser.class));
+        final Iterable<SettingsParser> parsers = ServiceLoader.load(SettingsParser.class);
         this.properties = parse((ConfigurableEnvironment) environment, parsers);
         this.properties.postProcess();
     }
 
     // visible for testing
-    FahrscheinConfigProperties parse(final ConfigurableEnvironment environment, final Collection<SettingsParser> parsers) {
-        final SettingsParser parser = parsers.stream()
+    FahrscheinConfigProperties parse(final ConfigurableEnvironment environment, final Iterable<SettingsParser> parsers) {
+        final SettingsParser parser = StreamSupport.stream(parsers.spliterator(), false)
                 .filter(SettingsParser::isApplicable)
                 .findFirst()
                 .orElseThrow(() -> new NoSuchElementException("No applicable nakadi-clients settings parser available"));

--- a/fahrschein-spring-boot-starter/src/test/java/org/zalando/spring/boot/fahrschein/nakadi/RegistryTest.java
+++ b/fahrschein-spring-boot-starter/src/test/java/org/zalando/spring/boot/fahrschein/nakadi/RegistryTest.java
@@ -1,16 +1,19 @@
 package org.zalando.spring.boot.fahrschein.nakadi;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.zalando.fahrschein.NakadiClient;
-import org.zalando.spring.boot.fahrschein.config.Registry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.zalando.spring.boot.fahrschein.config.Registry.generateBeanName;
 
 public class RegistryTest {
 
     @Test
-    public void testgeneratedBeanName() {
-        String beanName = Registry.generateBeanName("first", NakadiClient.class);
-        Assertions.assertThat(beanName).isEqualTo("firstNakadiClient");
+    public void testgeneratedBeanNameSimple() {
+        assertThat(generateBeanName(NakadiClient.class)).isEqualTo("nakadiClient");
+        assertThat(generateBeanName("", NakadiClient.class)).isEqualTo("NakadiClient");
+        assertThat(generateBeanName("first", NakadiClient.class)).isEqualTo("firstNakadiClient");
+        assertThat(generateBeanName("first-little", NakadiClient.class)).isEqualTo("firstLittleNakadiClient");
     }
 
 }

--- a/fahrschein-spring-boot-starter/src/test/java/org/zalando/spring/boot/fahrschein/nakadi/config/properties/ConsumerConfigTest.java
+++ b/fahrschein-spring-boot-starter/src/test/java/org/zalando/spring/boot/fahrschein/nakadi/config/properties/ConsumerConfigTest.java
@@ -3,7 +3,8 @@ package org.zalando.spring.boot.fahrschein.nakadi.config.properties;
 import org.junit.jupiter.api.Test;
 import org.zalando.fahrschein.http.api.ContentEncoding;
 
-import static com.google.common.collect.Lists.newArrayList;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ConsumerConfigTest {
@@ -78,7 +79,7 @@ public class ConsumerConfigTest {
         dc.setObjectMapperRef("jacksonObjectMapper");
         ConsumerConfig cc = new ConsumerConfig();
 
-        cc.getAuthorizations().setAdmins(AuthorizationUserServiceTeamLists.create(newArrayList(USER_5), newArrayList(), newArrayList(TEST_TEAM)));
+        cc.getAuthorizations().setAdmins(AuthorizationUserServiceTeamLists.create(List.of(USER_5), List.of(), List.of(TEST_TEAM)));
         cc.getHttp().setMaxIdleTime(1000L);
 
         cc.mergeWithDefaultConfig(dc);


### PR DESCRIPTION
Trying to reduce the amount of dependencies. The usage of guava in the spring-boot-starter was minimal, and can be replaced by a few lines of static code.

## Changes

- use the already copied "checkArgument" from the core fahrschein module
- replace list functions with ones from Java17
- re-implement camel case and hyphen case conversions with custom implementations (+ tests)
- remove dependency from build.gradle 
