### PR TITLE
#417 - Implement equals and hashcode for Metadata.

### DIFF
--- a/fahrschein/src/main/java/org/zalando/fahrschein/domain/Metadata.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/domain/Metadata.java
@@ -8,6 +8,7 @@ import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 
 @Immutable
 public final class Metadata {
@@ -81,6 +82,19 @@ public final class Metadata {
 
     public String getPublishedBy() {
         return publishedBy;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Metadata metadata = (Metadata) o;
+        return Objects.equals(eventType, metadata.eventType) && Objects.equals(eid, metadata.eid) && Objects.equals(partition, metadata.partition) && Objects.equals(version, metadata.version) && Objects.equals(publishedBy, metadata.publishedBy) && Objects.equals(occurredAt, metadata.occurredAt) && Objects.equals(receivedAt, metadata.receivedAt) && Objects.equals(flowId, metadata.flowId) && Objects.equals(spanCtx, metadata.spanCtx);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(eventType, eid, partition, version, publishedBy, occurredAt, receivedAt, flowId, spanCtx);
     }
 
     @Override

--- a/fahrschein/src/main/java/org/zalando/fahrschein/domain/Metadata.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/domain/Metadata.java
@@ -108,6 +108,7 @@ public final class Metadata {
                 ", publishedBy='" + publishedBy + '\'' +
                 ", receivedAt=" + receivedAt +
                 ", flowId='" + flowId + '\'' +
+                ", spanCtx=" + spanCtx.toString() +
                 '}';
     }
 }

--- a/fahrschein/src/test/java/org/zalando/fahrschein/domain/MetadataTest.java
+++ b/fahrschein/src/test/java/org/zalando/fahrschein/domain/MetadataTest.java
@@ -7,6 +7,7 @@ import java.time.ZoneOffset;
 import java.util.Collections;
 import java.util.UUID;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MetadataTest {
@@ -32,5 +33,22 @@ public class MetadataTest {
         assertTrue(metadata.toString().contains(metadata.getPublishedBy()));
         assertTrue(metadata.toString().contains(metadata.getReceivedAt().toString()));
         assertTrue(metadata.toString().contains(metadata.getFlowId()));
+    }
+
+    @Test
+    public void shouldHaveProperIdentity() {
+        final String eventType = "TEST-EVENT-TYPE";
+        final String eid = "a3e25946-5ae9-3964-91fa-26ecb7588d67";
+        final String partition = "partition1";
+        final String version = "v1";
+        final String publishedBy = "unauthenticated";
+        final OffsetDateTime occurredAt = OffsetDateTime.now(ZoneOffset.UTC);
+        final OffsetDateTime receivedAt = OffsetDateTime.now(ZoneOffset.UTC);
+        final String flowId = UUID.randomUUID().toString();
+
+        final Metadata metadata1 = new Metadata(eventType, eid, occurredAt, partition, version, publishedBy, receivedAt, flowId, Collections.emptyMap());
+        final Metadata metadata2 = new Metadata(eventType, eid, occurredAt, partition, version, publishedBy, receivedAt, flowId, Collections.emptyMap());
+
+        assertEquals(metadata1, metadata2);
     }
 }


### PR DESCRIPTION
This PR is adding the equals and hashcode methods implementations. It's a fix to the #417 issue.