### PR TITLE
Remove kotlin dependency & discover jackson modules via classpath introspection

### DIFF
--- a/fahrschein-spring-boot-starter/build.gradle
+++ b/fahrschein-spring-boot-starter/build.gradle
@@ -12,10 +12,6 @@ dependencies {
     implementation project(':fahrschein-http-spring')
     implementation project(':fahrschein-metrics-micrometer')
     implementation "org.springframework:spring-web:${property('spring.version')}"
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:${property('jackson.version')}"
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${property('jackson.version')}"
-    implementation "com.fasterxml.jackson.module:jackson-module-parameter-names:${property('jackson.version')}"
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${property('jackson.version')}"
     compileOnlyApi "org.springframework.boot:spring-boot-configuration-processor:${property('springboot.version')}"
     compileOnly "org.projectlombok:lombok:${lombok_version}"
     annotationProcessor "org.projectlombok:lombok:${lombok_version}"

--- a/fahrschein-spring-boot-starter/src/main/java/org/zalando/spring/boot/fahrschein/nakadi/config/ObjectMapperFactory.java
+++ b/fahrschein-spring-boot-starter/src/main/java/org/zalando/spring/boot/fahrschein/nakadi/config/ObjectMapperFactory.java
@@ -5,18 +5,16 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.fasterxml.jackson.module.kotlin.KotlinModule;
-import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 
 public class ObjectMapperFactory {
 
     public static ObjectMapper create() {
-        final ObjectMapper objectMapper = new ObjectMapper();
+        final ObjectMapper objectMapper = Jackson2ObjectMapperBuilder
+                .json()
+                .findModulesViaServiceLoader(true).build();
         objectMapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
         objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-        objectMapper.registerModules(new Jdk8Module(), new ParameterNamesModule(), new JavaTimeModule(), new KotlinModule.Builder().build());
         objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
         objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
         return objectMapper;


### PR DESCRIPTION
The ObjectMapper modules used for Fahrschein can be dicovered from the classpath. This avoids bloating fahrschein dependencies with potential use-cases like kotlin.
 
Closes #419 