### PR TITLE
Allow clients to correctly handle partial publishing failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,17 +195,18 @@ Fahrschein does not have sophisticated mechanisms for retry handling when publis
 to handle exceptions when publishing is to create a retry-wrapper around the `NakadiClient.publish` method.
 
 In case of a partial success or also in cases like validation errors, which are complete failures, Fahrschein
-will throw an `EventPublishingException` with the `BatchItemResponse`s included, as returned from Nakadi in the same order as your input.
+will throw an `EventPublishingException`. 
 
-These objects have the eid of the failed event, a `publishingStatus` (failed/aborted/submitted), the step where it failed and a detail string. If your application keeps track of eids, this allows it to resend only the failed items later. Otherwise, you can correlate the failed events based on their position in the sequence.
+You should first call `isRetryable()` on the exception, to identify if it would be allowed to retry publishing the batch.
+
+The exception also has the `BatchItemResponse`s included, as returned from Nakadi in the same order as your input. They also contain the event-ids of the failed events, a `publishingStatus` (failed/aborted/submitted), the step where they failed and a detail string. If your application keeps track of event-ids, this allows it to resend only the failed items later. Otherwise, you can correlate the failed events based on their position in the sequence.
 
 It also allows differentiating between validation errors, which likely don't need to be retried, as they are
 unlikely to succeed the next time, unless the event type definition is changed, and publishing errors
 which should be retried with some back-off.
 
 Recommendation: Implement a retry-with-backoff handler for `EventPublishingException`s, which, depending on
-your ordering consistency requirements, either retries the full batch, or retries the failed events based
-on the event-ids.
+your ordering consistency requirements, either retries the full batch, or retries the failed events. But, ensure to not retry events that failed in the `validating` step.
 
 ## Stopping and resuming streams
 

--- a/README.md
+++ b/README.md
@@ -195,11 +195,9 @@ Fahrschein does not have sophisticated mechanisms for retry handling when publis
 to handle exceptions when publishing is to create a retry-wrapper around the `NakadiClient.publish` method.
 
 In case of a partial success or also in cases like validation errors, which are complete failures, Fahrschein
-will throw an `EventPublishingException` with the `BatchItemResponse`s (as returned from Nakadi) for the failed
- items in the responses property.
+will throw an `EventPublishingException` with the `BatchItemResponse`s included, as returned from Nakadi in the same order as your input.
 
-These objects have the eid of the failed event, a `publishingStatus` (failed/aborted/submitted - but successful itemes are
-filtered out), the step where it failed and a detail string. If the application keeps track of eids, this allows it to resend only the failed items later.
+These objects have the eid of the failed event, a `publishingStatus` (failed/aborted/submitted), the step where it failed and a detail string. If your application keeps track of eids, this allows it to resend only the failed items later. Otherwise, you can correlate the failed events based on their position in the sequence.
 
 It also allows differentiating between validation errors, which likely don't need to be retried, as they are
 unlikely to succeed the next time, unless the event type definition is changed, and publishing errors

--- a/fahrschein/src/main/java/org/zalando/fahrschein/EventPersistenceException.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/EventPersistenceException.java
@@ -3,7 +3,7 @@ package org.zalando.fahrschein;
 import org.zalando.fahrschein.domain.BatchItemResponse;
 
 /**
- * <p>Exception thrown for server-side (partial) failures of event publishing.</p>
+ * <p>Exception thrown for server-side (partial) failures of event persistence, e.g. an event can not be stored due to Kafka unavailability.</p>
  *
  * <p>The exception contains an array of all {@link BatchItemResponse}s, independent of their status.
  * There is an ordering guarantee from Nakadi, so that you can correlate the elements in the response

--- a/fahrschein/src/main/java/org/zalando/fahrschein/EventPersistenceException.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/EventPersistenceException.java
@@ -1,0 +1,21 @@
+package org.zalando.fahrschein;
+
+import org.zalando.fahrschein.domain.BatchItemResponse;
+
+/**
+ * <p>Exception thrown for server-side (partial) failures of event publishing.</p>
+ *
+ * <p>The exception contains an array of all {@link BatchItemResponse}s, independent of their status.
+ * There is an ordering guarantee from Nakadi, so that you can correlate the elements in the response
+ * with your input batch, and potentially retry only the failed or aborted events. Every record includes the eid ({@link BatchItemResponse#getEid()})
+ * which can also be used to identify the event.
+ * </p>
+ */
+public class EventPersistenceException extends EventPublishingException {
+
+    public EventPersistenceException(BatchItemResponse[] responses)
+    {
+        super(responses);
+    }
+
+}

--- a/fahrschein/src/main/java/org/zalando/fahrschein/EventPublishingException.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/EventPublishingException.java
@@ -7,9 +7,12 @@ import java.util.Formatter;
 import java.util.Locale;
 
 /**
- * Thrown in case the client wasn't able to publish the given batch of events to Nakadi.
+ * Thrown in case the client wasn't able to publish full batch of events to Nakadi.
  *
- * The response will contain an array of {@code BatchItemResponse}.
+ * The response will contain an array of all {@code BatchItemResponse}s, independent of their status.
+ * There is an ordering guarantee from Nakadi, so that you can correlate the elements in the response
+ * with your input batch, and potentially retry only the failed events.
+ *
  */
 public class EventPublishingException extends IOException {
     private final BatchItemResponse[] responses;

--- a/fahrschein/src/main/java/org/zalando/fahrschein/EventPublishingException.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/EventPublishingException.java
@@ -11,7 +11,7 @@ import java.util.Locale;
  *
  * The response will contain an array of all {@code BatchItemResponse}s, independent of their status.
  * There is an ordering guarantee from Nakadi, so that you can correlate the elements in the response
- * with your input batch, and potentially retry only the failed events.
+ * with your input batch, and potentially retry only the failed events. Every record includes the eid (event id) which can be used to identify the event.
  *
  */
 public class EventPublishingException extends IOException {

--- a/fahrschein/src/main/java/org/zalando/fahrschein/EventPublishingException.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/EventPublishingException.java
@@ -7,26 +7,25 @@ import java.util.Formatter;
 import java.util.Locale;
 
 /**
- * Thrown in case the client wasn't able to publish full batch of events to Nakadi.
+ * <p>Base class for exceptions thrown when publishing events to Nakadi.</p>
  *
- * The response will contain an array of all {@code BatchItemResponse}s, independent of their status.
+ * <p>The exception will contain an array of all {@link BatchItemResponse}s, independent of their status.
  * There is an ordering guarantee from Nakadi, so that you can correlate the elements in the response
- * with your input batch, and potentially retry only the failed events. Every record includes the eid (event id) which can be used to identify the event.
+ * with your input batch, and potentially retry only the failed or aborted events. Every record includes the eid (event id)
+ * which can also be used to identify the event.</p>
  *
- * Based on the HTTP response code, the EventPublishingException will be retryable or not. Partially
- * successfully published batches are retryable, while unprocessable entities are not.
- *
+ * <p>Based on the exception, the batch can be retried or not. Partially successfully published batches are
+ * retryable (see {@link EventPersistenceException}), while batches rejected as unprocessable entities are not
+ * (see {@link EventValidationException}).
+ * </p>
  */
-public class EventPublishingException extends IOException {
+public abstract class EventPublishingException extends IOException {
 
     private final BatchItemResponse[] responses;
 
-    private final boolean retryable;
-
-    public EventPublishingException(BatchItemResponse[] responses, boolean retryable) {
+    public EventPublishingException(BatchItemResponse[] responses) {
         super(formatMessage(responses));
         this.responses = responses;
-        this.retryable = retryable;
     }
 
     private static String formatMessage(BatchItemResponse[] responses) {
@@ -50,10 +49,4 @@ public class EventPublishingException extends IOException {
         return responses;
     }
 
-    /**
-     * @return true, if the batch can be retried.
-     */
-    public boolean isRetryable() {
-        return retryable;
-    }
 }

--- a/fahrschein/src/main/java/org/zalando/fahrschein/EventValidationException.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/EventValidationException.java
@@ -1,0 +1,20 @@
+package org.zalando.fahrschein;
+
+import org.zalando.fahrschein.domain.BatchItemResponse;
+
+/**
+ * <p>Exception thrown during publishing of events, in case the batch fails the validation phase.
+ * </p>
+ * <p>The exception will contain an array of all {@link BatchItemResponse}s, independent of their status.
+ * There is an ordering guarantee from Nakadi, so that you can correlate the elements in the response
+ * with your input batch, and potentially retry only the failed or aborted events. Every record includes the eid ({@link BatchItemResponse#getEid()})
+ * which can also be used to identify the event.
+ * </p>
+ */
+public class EventValidationException extends EventPublishingException {
+
+    public EventValidationException(BatchItemResponse[] responses)
+    {
+        super(responses);
+    }
+}

--- a/fahrschein/src/main/java/org/zalando/fahrschein/ProblemHandlingRequest.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/ProblemHandlingRequest.java
@@ -113,15 +113,15 @@ class ProblemHandlingRequest implements Request {
 
     private void handleBatchItemResponse(JsonNode rootNode) throws IOException {
         final BatchItemResponse[] responses = objectMapper.treeToValue(rootNode, BatchItemResponse[].class);
-        final List<BatchItemResponse> failed = new ArrayList<>(responses.length);
+        boolean partiallyFailed = false;
         for (BatchItemResponse batchItemResponse : responses) {
-            if (batchItemResponse.getPublishingStatus() != BatchItemResponse.PublishingStatus.SUBMITTED) {
-                failed.add(batchItemResponse);
+            if(batchItemResponse.getPublishingStatus() != BatchItemResponse.PublishingStatus.SUBMITTED) {
+               partiallyFailed = true;
+               break;
             }
         }
-        if (!failed.isEmpty()) {
-            // TODO: attach corresponding events?
-            throw new EventPublishingException(failed.toArray(new BatchItemResponse[failed.size()]));
+        if (partiallyFailed) {
+            throw new EventPublishingException(responses);
         }
     }
 

--- a/fahrschein/src/main/java/org/zalando/fahrschein/ProblemHandlingRequest.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/ProblemHandlingRequest.java
@@ -11,8 +11,6 @@ import org.zalando.fahrschein.http.api.Response;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
-import java.util.ArrayList;
-import java.util.List;
 
 import static org.zalando.fahrschein.http.api.ContentType.APPLICATION_JSON;
 import static org.zalando.fahrschein.http.api.ContentType.APPLICATION_PROBLEM_JSON;
@@ -113,16 +111,11 @@ class ProblemHandlingRequest implements Request {
 
     private void handleBatchItemResponse(JsonNode rootNode) throws IOException {
         final BatchItemResponse[] responses = objectMapper.treeToValue(rootNode, BatchItemResponse[].class);
-        boolean partiallyFailed = false;
         for (BatchItemResponse batchItemResponse : responses) {
             if(batchItemResponse.getPublishingStatus() == BatchItemResponse.PublishingStatus.FAILED ||
                 batchItemResponse.getPublishingStatus() == BatchItemResponse.PublishingStatus.ABORTED) {
-               partiallyFailed = true;
-               break;
+                throw new EventPublishingException(responses);
             }
-        }
-        if (partiallyFailed) {
-            throw new EventPublishingException(responses);
         }
     }
 

--- a/fahrschein/src/main/java/org/zalando/fahrschein/ProblemHandlingRequest.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/ProblemHandlingRequest.java
@@ -115,7 +115,8 @@ class ProblemHandlingRequest implements Request {
         final BatchItemResponse[] responses = objectMapper.treeToValue(rootNode, BatchItemResponse[].class);
         boolean partiallyFailed = false;
         for (BatchItemResponse batchItemResponse : responses) {
-            if(batchItemResponse.getPublishingStatus() != BatchItemResponse.PublishingStatus.SUBMITTED) {
+            if(batchItemResponse.getPublishingStatus() == BatchItemResponse.PublishingStatus.FAILED ||
+                batchItemResponse.getPublishingStatus() == BatchItemResponse.PublishingStatus.ABORTED) {
                partiallyFailed = true;
                break;
             }

--- a/fahrschein/src/main/java/org/zalando/fahrschein/domain/BatchItemResponse.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/domain/BatchItemResponse.java
@@ -55,6 +55,9 @@ public final class BatchItemResponse {
         this.detail = detail;
     }
 
+    /**
+     * @return the event id
+     */
     public String getEid() {
         return eid;
     }

--- a/fahrschein/src/test/java/org/zalando/fahrschein/NakadiClientTest.java
+++ b/fahrschein/src/test/java/org/zalando/fahrschein/NakadiClientTest.java
@@ -307,7 +307,7 @@ public class NakadiClientTest {
         server.expectRequestTo("http://example.com/event-types/foobar/events", "POST")
                 .andExpectJsonPath("$[0].id", equalTo("1"))
                 .andExpectJsonPath("$[1].id", equalTo("2"))
-                .andRespondWith(422, ContentType.APPLICATION_JSON, "[{\"eid\":\"event-one\",\"publishing_status\":\"aborted\",\"step\":\"validating\",\"detail\":\"baz\"}]")
+                .andRespondWith(422, ContentType.APPLICATION_JSON, "[{\"eid\":\"event-one\",\"publishing_status\":\"failed\",\"step\":\"validating\",\"detail\":\"baz\"}]")
                 .setup();
 
         EventPublishingHandler eventPublishingHandler = mock(EventPublishingHandler.class);

--- a/fahrschein/src/test/java/org/zalando/fahrschein/NakadiClientTest.java
+++ b/fahrschein/src/test/java/org/zalando/fahrschein/NakadiClientTest.java
@@ -337,7 +337,7 @@ public class NakadiClientTest {
                 .andExpectJsonPath("$[1].id", equalTo("2"))
                 .andRespondWith(207, ContentType.APPLICATION_JSON,
                         "[{\"eid\":\"event-one\",\"publishing_status\":\"failed\",\"step\":\"publishing\",\"detail\":\"baz\"},"
-                 + "{\"eid\":\"event-two\",\"publishing_status\":\"submitted\",\"step\":\"none\",\"detail\":\"\"}]")
+                 + "{\"eid\":\"event-two\",\"publishing_status\":\"submitted\",\"step\":\"publishing\",\"detail\":\"\"}]")
                 .setup();
 
         EventPublishingHandler eventPublishingHandler = mock(EventPublishingHandler.class);

--- a/fahrschein/src/test/java/org/zalando/fahrschein/NakadiClientTest.java
+++ b/fahrschein/src/test/java/org/zalando/fahrschein/NakadiClientTest.java
@@ -325,7 +325,7 @@ public class NakadiClientTest {
         });
 
         server.verify();
-        assertEquals("Event publishing of [event-one] returned status [aborted] in step [validating] with detail [baz]", expectedException.getMessage());
+        assertEquals("Event publishing of [event-one] returned status [failed] in step [validating] with detail [baz]", expectedException.getMessage());
         verify(eventPublishingHandler, Mockito.atMostOnce()).onPublish(eq(eventName), eq(someEvents));
         verify(eventPublishingHandler, Mockito.atMostOnce()).onError(eq(someEvents), eq(expectedException));
     }

--- a/fahrschein/src/test/java/org/zalando/fahrschein/NakadiClientTest.java
+++ b/fahrschein/src/test/java/org/zalando/fahrschein/NakadiClientTest.java
@@ -336,7 +336,7 @@ public class NakadiClientTest {
                 .andExpectJsonPath("$[0].id", equalTo("1"))
                 .andExpectJsonPath("$[1].id", equalTo("2"))
                 .andRespondWith(207, ContentType.APPLICATION_JSON,
-                        "[{\"eid\":\"event-one\",\"publishing_status\":\"failed\",\"step\":\"validating\",\"detail\":\"baz\"},"
+                        "[{\"eid\":\"event-one\",\"publishing_status\":\"failed\",\"step\":\"publishing\",\"detail\":\"baz\"},"
                  + "{\"eid\":\"event-two\",\"publishing_status\":\"submitted\",\"step\":\"none\",\"detail\":\"\"}]")
                 .setup();
 

--- a/fahrschein/src/test/java/org/zalando/fahrschein/NakadiClientTest.java
+++ b/fahrschein/src/test/java/org/zalando/fahrschein/NakadiClientTest.java
@@ -321,7 +321,7 @@ public class NakadiClientTest {
         List<SomeEvent> someEvents = asList(new SomeEvent("1"), new SomeEvent("2"));
 
         EventPublishingException expectedException = assertThrows(EventPublishingException.class, () -> {
-            client.publish("foobar", asList(new SomeEvent("1"), new SomeEvent("2")));
+            client.publish("foobar", someEvents);
         });
 
         server.verify();
@@ -351,7 +351,7 @@ public class NakadiClientTest {
         List<SomeEvent> someEvents = asList(new SomeEvent("1"), new SomeEvent("2"));
 
         EventPublishingException expectedException = assertThrows(EventPublishingException.class, () -> {
-            client.publish("foobar", asList(new SomeEvent("1"), new SomeEvent("2")));
+            client.publish("foobar", someEvents);
         });
 
         server.verify();

--- a/fahrschein/src/test/java/org/zalando/fahrschein/ProblemHandlingRequestTest.java
+++ b/fahrschein/src/test/java/org/zalando/fahrschein/ProblemHandlingRequestTest.java
@@ -117,7 +117,7 @@ public class ProblemHandlingRequestTest {
     public void shouldHandleMultiStatus() throws IOException {
         when(response.getStatusCode()).thenReturn(207);
         when(response.getStatusText()).thenReturn("Multistatus");
-        when(response.getBody()).thenReturn(new ByteArrayInputStream("[{\"publishing_status\":\"failed\",\"step\":\"validating\",\"detail\":\"baz\"}]".getBytes(StandardCharsets.UTF_8)));
+        when(response.getBody()).thenReturn(new ByteArrayInputStream("[{\"publishing_status\":\"failed\",\"step\":\"publishing\",\"detail\":\"baz\"}]".getBytes(StandardCharsets.UTF_8)));
 
         final Headers headers = new HeadersImpl();
         headers.setContentType(ContentType.APPLICATION_JSON);
@@ -125,7 +125,7 @@ public class ProblemHandlingRequestTest {
 
         when(request.execute()).thenReturn(response);
 
-        assertThrows(EventPublishingException.class, () -> {
+        assertThrows(EventPersistenceException.class, () -> {
             problemHandlingRequest.execute();
         });
     }


### PR DESCRIPTION
When publishing batches, Nakadi can return partial success. So far, we throw an `EventPublishingException`, independently of a validation vs. persistence error, and we  only include the failed BatchItemResponse entries. This means without event-id correlation locally it is impossible for teams to figure out which items from the batch need retrying. It also not obvious from the error, if the batch can be retried or not.

## Changes

- Removes the filtering for only failed events when crafting the EventPublishingException
- Introduces subclasses for validation vs. persistence errors: `EventPersistenceException` for persistence failures which can be retried, `EventValidationException` for validation errors which need fixing on the client side and should not be retried.
- Adapts the documentation in the README 

## Rationale 

This change allows clients to rely on the element ordering in the thrown exception when considering retrying only the failed events, and properly distinguishing between validation and persistence failures.

Next step towards finishing  #415.
