### PR TITLE
StreamParameters refresher (documentation + new parameter support)

### DIFF
--- a/fahrschein/src/test/java/org/zalando/fahrschein/StreamParametersTest.java
+++ b/fahrschein/src/test/java/org/zalando/fahrschein/StreamParametersTest.java
@@ -2,16 +2,26 @@ package org.zalando.fahrschein;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Optional;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.collection.IsArrayWithSize.arrayWithSize;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class StreamParametersTest {
 
     @Test
-    public void createsAValidQueryParamString() throws IllegalArgumentException {
+    public void createsDefaultQueryParam() {
+        final StreamParameters streamParameters = new StreamParameters();
+        final String queryString = streamParameters.toQueryString();
+        assertEquals("", queryString);
+    }
+
+    @Test
+    public void createsAValidQueryParamString() {
         final StreamParameters streamParameters = new StreamParameters()
                 .withBatchLimit(102)
                 .withStreamLimit(103)
@@ -19,12 +29,13 @@ public class StreamParametersTest {
                 .withStreamTimeout(105)
                 .withStreamKeepAliveLimit(106)
                 .withMaxUncommittedEvents(107)
-                .withCommitTimeout(60);
+                .withCommitTimeout(60)
+                .withBatchTimespan(10);
 
         final String queryString = streamParameters.toQueryString();
         final String[] queryParamStrings = queryString.split("&");
 
-        assertThat(queryParamStrings, arrayWithSize(7));
+        assertThat(queryParamStrings, arrayWithSize(8));
 
         assertThat(queryParamStrings, arrayContainingInAnyOrder(
                 "batch_limit=102",
@@ -33,43 +44,18 @@ public class StreamParametersTest {
                 "stream_timeout=105",
                 "stream_keep_alive_limit=106",
                 "max_uncommitted_events=107",
-                "commit_timeout=60"
+                "commit_timeout=60",
+                "batch_timespan=10"
         ));
-    }
 
-    @Test
-    public void streamParametersWithStreamTimeoutFailure() throws IllegalArgumentException {
-
-
-        IllegalArgumentException expectedException = assertThrows(IllegalArgumentException.class, () -> {
-            new StreamParameters()
-                    .withBatchFlushTimeout(100)
-                    .withStreamTimeout(50);
-        });
-
-        assertThat(expectedException.getMessage(), is("stream_timeout is lower than batch_flush_timeout."));
-    }
-
-    @Test
-    public void streamParametersWithStreamLimitFailure() {
-
-        IllegalArgumentException expectedException = assertThrows(IllegalArgumentException.class, () -> {
-            new StreamParameters()
-                    .withBatchLimit(20)
-                    .withStreamLimit(10);
-        });
-        assertThat(expectedException.getMessage(), is("streamLimit is lower than batch_limit."));
-    }
-
-    @Test
-    public void streamParametersWithBatchLimitZero() throws IllegalArgumentException {
-        IllegalArgumentException expectedException = assertThrows(IllegalArgumentException.class, () -> {
-            new StreamParameters()
-                    .withBatchLimit(0)
-                    .withStreamLimit(10);
-        });
-
-        assertThat(expectedException.getMessage(), is("batch_limit can't be lower than 1."));
+        assertEquals(Optional.of(102), streamParameters.getBatchLimit());
+        assertEquals(Optional.of(103), streamParameters.getStreamLimit());
+        assertEquals(Optional.of(104), streamParameters.getBatchFlushTimeout());
+        assertEquals(Optional.of(105), streamParameters.getStreamTimeout());
+        assertEquals(Optional.of(106), streamParameters.getStreamKeepAliveLimit());
+        assertEquals(Optional.of(107), streamParameters.getMaxUncommittedEvents());
+        assertEquals(Optional.of(60), streamParameters.getCommitTimeout());
+        assertEquals(Optional.of(10), streamParameters.getBatchTimespan());
     }
 
 }


### PR DESCRIPTION
## Changes

- Supports stream parameter "batch_timespan" (closes #431)
- updates and add API documentation based on the latest API docs from Nakadi, incl. documentation of defaults
- Removes client-side validation of parameters (duplicates what the server will reject anyway)
- Removes an outdated comment from 2017 about a "silent bug". Nowadays Nakadi rejects a batch_limit of 0. (Verified and tested with Nakadi team)