### PR TITLE
Consistency in stream parameters support for spring boot

### DIFF
--- a/fahrschein-spring-boot-starter/README.md
+++ b/fahrschein-spring-boot-starter/README.md
@@ -83,122 +83,127 @@ Clients are identified by a *Client ID*, for instance `example` in the sample ab
 
 For a complete overview of available properties, they type and default value please refer to the following table:
 
-| Configuration                                 | Data type          | Default / Comment                                                                                  |
-|-----------------------------------------------|--------------------|----------------------------------------------------------------------------------------------------|
-| `fahrschein`                                  |                    |                                                                                                    |
-| `├── defaults`                                |                    |                                                                                                    |
-| `│   ├── nakadi-url`                          | `String`           | none                                                                                               |
-| `│   ├── application-name`                    | `String`           | none                                                                                               |
-| `│   ├── authorizations`                      |                    | none                                                                                               |
-| `│   │   ├── admins`                          |                    | none                                                                                               |
-| `│   │   │   ├── users`                       | `List<String>`     | none                                                                                               |
-| `│   │   │   ├── services`                    | `List<String>`     | none                                                                                               |
-| `│   │   │   └── teams`                       | `List<String>`     | none                                                                                               |
-| `│   │   ├── readers`                         |                    | none                                                                                               |
-| `│   │   │   ├── users`                       | `List<String>`     | none                                                                                               |
-| `│   │   │   ├── services`                    | `List<String>`     | none                                                                                               |
-| `│   │   │   └── teams`                       | `List<String>`     | none                                                                                               |
-| `│   │   └── writers`                         |                    | none                                                                                               |
-| `│   │       ├── users`                       | `List<String>`     | none                                                                                               |
-| `│   │       ├── services`                    | `List<String>`     | none                                                                                               |
-| `│   │       └── teams`                       | `List<String>`     | none                                                                                               |
-| `│   ├── consumer-group`                      | `String`           | none                                                                                               |
-| `│   ├── autostart-enabled`                   | `boolean`          | `true`                                                                                             |
-| `│   ├── record-metrics`                      | `boolean`          | `false`                                                                                            |
-| `│   ├── read-from`                           | `Position`         | `end` (`begin`)                                                                                    |
-| `│   ├── oauth`                               |                    |                                                                                                    |
-| `│   │   ├── enabled`                         | `boolean`          | `false`                                                                                            |
-| `│   │   └── access-token-id`                 | `String`           | none                                                                                               |
-| `│   ├── http`                                |                    |                                                                                                    |
-| `│   │   ├── socket-timeout`                  | `TimeSpan`         | `5 seconds`                                                                                        |
-| `│   │   ├── connect-timeout`                 | `TimeSpan`         | `5 seconds`                                                                                        |
-| `│   │   ├── connection-request-timeout`      | `TimeSpan`         | `5 seconds`                                                                                        |
-| `│   │   ├── content-encoding`                | `ContentEncoding`  | `gzip` (`identity`)                                                                                |
-| `│   │   ├── content-compression-enabled`     | `boolean`          | `false`                                                                                            |
-| `│   │   ├── buffer-size`                     | `int`              | `512`                                                                                              |
-| `│   │   ├── connection-time-to-live`         | `TimeSpan`         | `30 seconds`                                                                                       |
-| `│   │   ├── max-connections-total`           | `int`              | `3`                                                                                                |
-| `│   │   ├── max-connections-per-route`       | `int`              | `3`                                                                                                |
-| `│   │   ├── evict-expired-connections`       | `boolean`          | `true`                                                                                             |
-| `│   │   ├── evict-idle-connections`          | `boolean`          | `true`                                                                                             |
-| `│   │   └── max-idle-time`                   | `int`              | `10_000`                                                                                           |
-| `│   ├── backoff`                             |                    |                                                                                                    |
-| `│   │   ├── enabled`                         | `boolean`          | `false`                                                                                            |
-| `│   │   ├── intial-delay`                    | `TimeSpan`         | `500 milliseconds`                                                                                 |
-| `│   │   ├── max-delay`                       | `TimeSpan`         | `10 minutes`                                                                                       |
-| `│   │   ├── backoff-factor`                  | `double`           | `1.5`                                                                                              |
-| `│   │   ├── max-retries`                     | `int`              | `1`                                                                                                |
-| `│   │   └── jitter`                          |                    |                                                                                                    |
-| `│   │       ├── enabled`                     | `boolean`          | `false`                                                                                            |
-| `│   │       └── type`                        | `JitterType`       | `equal` (`full`)                                                                                   |
-| `│   ├── threads`                             |                    |                                                                                                    |
-| `│   │   └── listener-pool-size`              | `int`              | `1`                                                                                                |
-| `│   ├── oauth`                               |                    |                                                                                                    |
-| `│   │   ├── enabled`                         | `boolean`          | `false`                                                                                            |
-| `│   │   └── access-token-id`                 | `String`           | none                                                                                               |
-| `│   ├── stream-parameters`                   |                    |
-| `│   │    ├── batch-limit`                     |`int`                | [default value](https://nakadi.io/manual.html#/subscriptions/subscription_id/events_get*batch_limit)            |                                                                                               |
-| `│   │    ├── stream-limit`                    | `int`              | [default value](https://nakadi.io/manual.html#/subscriptions/subscription_id/events_get*stream_limit)            |                                                                                               |
-| `│   │    ├── batch-flush-timeout`             | `int`              | in seconds [default value](https://nakadi.io/manual.html#/subscriptions/subscription_id/events_get*batch_flush_timeout) |                                                                                               |
-| `│   │    ├── stream-timeout`                  | `int`              | in seconds [default value](https://nakadi.io/manual.html#/subscriptions/subscription_id/events_get*stream_timeout) |                                                                                               |
-| `│   │    └── max-uncommitted-events`          | `int`              | [default value](https://nakadi.io/manual.html#/subscriptions/subscription_id/events_get*max_uncommitted_events)            |
-| `│`                                           |                    |                                                                                                    |
-| `└── consumers`                               |                    |                                                                                                    |
-| `    └── <id>`                                | `String`           |                                                                                                    |
-| `        ├── topics`                          | `List<String>`     |                                                                                                    |
-| `        ├── nakadi-url`                      | `String`           | none                                                                                               |
-| `        ├── application-name`                | `String`           | none                                                                                               |
-| `        ├── authorizations`                  |                    | none                                                                                               |
-| `        │   ├── admins`                      |                    | none                                                                                               |
-| `        │   │   ├── users`                   | `List<String>`     | none                                                                                               |
-| `        │   │   ├── services`                | `List<String>`     | none                                                                                               |
-| `        │   │   └── teams`                   | `List<String>`     | none                                                                                               |
-| `        │   ├── readers`                     |                    | none                                                                                               |
-| `        │   │   ├── users`                   | `List<String>`     | none                                                                                               |
-| `        │   │   ├── services`                | `List<String>`     | none                                                                                               |
-| `        │   │   └── teams`                   | `List<String>`     | none                                                                                               |
-| `        │   └── writers`                     |                    | none                                                                                               |
-| `        │       ├── users`                   | `List<String>`     | none                                                                                               |
-| `        │       ├── services`                | `List<String>`     | none                                                                                               |
-| `        │       └── teams`                   | `List<String>`     | none                                                                                               |
-| `        ├── consumer-group`                  | `String`           | none                                                                                               |
-| `        ├── autostart-enabled`               | `boolean`          | `true`                                                                                             |
-| `        ├── record-metrics`                  | `boolean`          | `false`                                                                                            |
-| `        ├── read-From`                       | `Position`         | `end` (`begin`)                                                                                    |
-| `        ├── oauth`                           |                    |                                                                                                    |
-| `        │   ├── enabled`                     | `boolean`          | `false`                                                                                            |
-| `        │   └── access-token-id`             | `String`           | none                                                                                               |
-| `        ├── http`                            |                    |                                                                                                    |
-| `        │   ├── socket-timeout`              | `TimeSpan`         | `5 seconds`                                                                                        |
-| `        │   ├── connect-timeout`             | `TimeSpan`         | `5 seconds`                                                                                        |
-| `        │   ├── connection-request-timeout`  | `TimeSpan`         | `5 seconds`                                                                                        |
-| `        │   ├── content-encoding`            | `ContentEncoding`  | `gzip` (`identity`)                                                                                |
-| `        │   ├── content-compression-enabled` | `boolean`          | `false`                                                                                            |
-| `        │   ├── buffer-size`                 | `int`              | `512`                                                                                              |
-| `        │   ├── connection-time-to-live`     | `TimeSpan`         | `30 seconds`                                                                                       |
-| `        │   ├── max-connections-total`       | `int`              | `3`                                                                                                |
-| `        │   ├── max-connections-per-route`   | `int`              | `3`                                                                                                |
-| `        │   ├── evict-expired-connections`   | `boolean`          | `true`                                                                                             |
-| `        │   ├── evict-idle-connections`      | `boolean`          | `true`                                                                                             |
-| `        │   └── max-idle-time`               | `int`              | `10_000`                                                                                           |
-| `        ├── backoff`                         |                    |                                                                                                    |
-| `        │   ├── enabled`                     | `boolean`          | `false`                                                                                            |
-| `        │   ├── intial-delay`                | `TimeSpan`         | `500 milliseconds`                                                                                 |
-| `        │   ├── max-delay`                   | `TimeSpan`         | `10 minutes`                                                                                       |
-| `        │   ├── backoff-factor`              | `double`           | `1.5`                                                                                              |
-| `        │   ├── max-retries`                 | `int`              | `1`                                                                                                |
-| `        │   └── jitter`                      |                    |                                                                                                    |
-| `        │       ├── enabled`                 | `boolean`          | `false`                                                                                            |
-| `        │       └── type`                    | `JitterType`       | `equal` (`full`)                                                                                   |
-| `        ├── threads`                         |                    |                                                                                                    |
-| `        │   └── listener-pool-size`          | `int`              | `1`                                                                                                |
-| `        ├── oauth`                           |                    |                                                                                                    |
-| `        │   ├── enabled`                     | `boolean`          | `false`                                                                                            |
-| `        │   └── access-token-id`             | `String`           | none                                                                                               |
-| `        └── stream-parameters`               |                    |
-| `        │   ├── batch-limit`                 | `int`              | [default value](https://nakadi.io/manual.html#/subscriptions/subscription_id/events_get*batch_limit)            |
-| `        │   ├── stream-limit`                | `int`              | [default value](https://nakadi.io/manual.html#/subscriptions/subscription_id/events_get*stream_limit)            |
-| `        │   ├── batch-flush-timeout`         | `int`              | in seconds [default value](https://nakadi.io/manual.html#/subscriptions/subscription_id/events_get*batch_flush_timeout) |
-| `        │   ├── stream-timeout`              | `int`              | in seconds [default value](https://nakadi.io/manual.html#/subscriptions/subscription_id/events_get*stream_timeout) |
-| `        │   └── max-uncommitted-events`      | `int`              | [default value](https://nakadi.io/manual.html#/subscriptions/subscription_id/events_get*max_uncommitted_events)            |
-
+| Configuration                                 | Data type         | Default / Comment                                                                                                       |
+|-----------------------------------------------|-------------------|-------------------------------------------------------------------------------------------------------------------------|
+| `fahrschein`                                  |                   |                                                                                                                         |
+| `├── defaults`                                |                   |                                                                                                                         |
+| `│   ├── nakadi-url`                          | `String`          | none                                                                                                                    |
+| `│   ├── application-name`                    | `String`          | none                                                                                                                    |
+| `│   ├── authorizations`                      |                   | none                                                                                                                    |
+| `│   │   ├── admins`                          |                   | none                                                                                                                    |
+| `│   │   │   ├── users`                       | `List<String>`    | none                                                                                                                    |
+| `│   │   │   ├── services`                    | `List<String>`    | none                                                                                                                    |
+| `│   │   │   └── teams`                       | `List<String>`    | none                                                                                                                    |
+| `│   │   ├── readers`                         |                   | none                                                                                                                    |
+| `│   │   │   ├── users`                       | `List<String>`    | none                                                                                                                    |
+| `│   │   │   ├── services`                    | `List<String>`    | none                                                                                                                    |
+| `│   │   │   └── teams`                       | `List<String>`    | none                                                                                                                    |
+| `│   │   └── writers`                         |                   | none                                                                                                                    |
+| `│   │       ├── users`                       | `List<String>`    | none                                                                                                                    |
+| `│   │       ├── services`                    | `List<String>`    | none                                                                                                                    |
+| `│   │       └── teams`                       | `List<String>`    | none                                                                                                                    |
+| `│   ├── consumer-group`                      | `String`          | none                                                                                                                    |
+| `│   ├── autostart-enabled`                   | `boolean`         | `true`                                                                                                                  |
+| `│   ├── record-metrics`                      | `boolean`         | `false`                                                                                                                 |
+| `│   ├── read-from`                           | `Position`        | `end` (`begin`)                                                                                                         |
+| `│   ├── oauth`                               |                   |                                                                                                                         |
+| `│   │   ├── enabled`                         | `boolean`         | `false`                                                                                                                 |
+| `│   │   └── access-token-id`                 | `String`          | none                                                                                                                    |
+| `│   ├── http`                                |                   |                                                                                                                         |
+| `│   │   ├── socket-timeout`                  | `TimeSpan`        | `5 seconds`                                                                                                             |
+| `│   │   ├── connect-timeout`                 | `TimeSpan`        | `5 seconds`                                                                                                             |
+| `│   │   ├── connection-request-timeout`      | `TimeSpan`        | `5 seconds`                                                                                                             |
+| `│   │   ├── content-encoding`                | `ContentEncoding` | `gzip` (`identity`)                                                                                                     |
+| `│   │   ├── content-compression-enabled`     | `boolean`         | `false`                                                                                                                 |
+| `│   │   ├── buffer-size`                     | `int`             | `512`                                                                                                                   |
+| `│   │   ├── connection-time-to-live`         | `TimeSpan`        | `30 seconds`                                                                                                            |
+| `│   │   ├── max-connections-total`           | `int`             | `3`                                                                                                                     |
+| `│   │   ├── max-connections-per-route`       | `int`             | `3`                                                                                                                     |
+| `│   │   ├── evict-expired-connections`       | `boolean`         | `true`                                                                                                                  |
+| `│   │   ├── evict-idle-connections`          | `boolean`         | `true`                                                                                                                  |
+| `│   │   └── max-idle-time`                   | `int`             | `10_000`                                                                                                                |
+| `│   ├── backoff`                             |                   |                                                                                                                         |
+| `│   │   ├── enabled`                         | `boolean`         | `false`                                                                                                                 |
+| `│   │   ├── intial-delay`                    | `TimeSpan`        | `500 milliseconds`                                                                                                      |
+| `│   │   ├── max-delay`                       | `TimeSpan`        | `10 minutes`                                                                                                            |
+| `│   │   ├── backoff-factor`                  | `double`          | `1.5`                                                                                                                   |
+| `│   │   ├── max-retries`                     | `int`             | `1`                                                                                                                     |
+| `│   │   └── jitter`                          |                   |                                                                                                                         |
+| `│   │       ├── enabled`                     | `boolean`         | `false`                                                                                                                 |
+| `│   │       └── type`                        | `JitterType`      | `equal` (`full`)                                                                                                        |
+| `│   ├── threads`                             |                   |                                                                                                                         |
+| `│   │   └── listener-pool-size`              | `int`             | `1`                                                                                                                     |
+| `│   ├── oauth`                               |                   |                                                                                                                         |
+| `│   │   ├── enabled`                         | `boolean`         | `false`                                                                                                                 |
+| `│   │   └── access-token-id`                 | `String`          | none                                                                                                                    |
+| `│   └── stream-parameters`                   |                   |                                                                                                                         |
+| `│       ├── batch-limit`                     | `int`             | [default value](https://nakadi.io/manual.html#/subscriptions/subscription_id/events_get*batch_limit)                    |                                                                    
+| `│       ├── stream-limit`                    | `int`             | [default value](https://nakadi.io/manual.html#/subscriptions/subscription_id/events_get*stream_limit)                   |                                                                      
+| `│       ├── batch-flush-timeout`             | `TimeSpan`        | [default value](https://nakadi.io/manual.html#/subscriptions/subscription_id/events_get*batch_flush_timeout)            |
+| `│       ├── stream-timeout`                  | `TimeSpan`        | [default value](https://nakadi.io/manual.html#/subscriptions/subscription_id/events_get*stream_timeout)                 |
+| `│       ├── commit-timeout`                  | `TimeSpan`        | [default value](https://nakadi.io/manual.html#/subscriptions/subscription_id/events_get*commit_timeout)                 |
+| `│       ├── stream-keep-alive-limit`         | `int`             | [default value](https://nakadi.io/manual.html#/subscriptions/subscription_id/events_get*stream_keep_alive_limit)        |
+| `│       ├── batch-timespan`                  | `TimeSpan`        | none                                                                                                                    |
+| `│       └── max-uncommitted-events`          | `int`             | [default value](https://nakadi.io/manual.html#/subscriptions/subscription_id/events_get*max_uncommitted_events)         |
+| `│`                                           |                   |                                                                                                                         |
+| `└── consumers`                               |                   |                                                                                                                         |
+| `    └── <id>`                                | `String`          |                                                                                                                         |
+| `        ├── topics`                          | `List<String>`    |                                                                                                                         |
+| `        ├── nakadi-url`                      | `String`          | none                                                                                                                    |
+| `        ├── application-name`                | `String`          | none                                                                                                                    |
+| `        ├── authorizations`                  |                   | none                                                                                                                    |
+| `        │   ├── admins`                      |                   | none                                                                                                                    |
+| `        │   │   ├── users`                   | `List<String>`    | none                                                                                                                    |
+| `        │   │   ├── services`                | `List<String>`    | none                                                                                                                    |
+| `        │   │   └── teams`                   | `List<String>`    | none                                                                                                                    |
+| `        │   ├── readers`                     |                   | none                                                                                                                    |
+| `        │   │   ├── users`                   | `List<String>`    | none                                                                                                                    |
+| `        │   │   ├── services`                | `List<String>`    | none                                                                                                                    |
+| `        │   │   └── teams`                   | `List<String>`    | none                                                                                                                    |
+| `        │   └── writers`                     |                   | none                                                                                                                    |
+| `        │       ├── users`                   | `List<String>`    | none                                                                                                                    |
+| `        │       ├── services`                | `List<String>`    | none                                                                                                                    |
+| `        │       └── teams`                   | `List<String>`    | none                                                                                                                    |
+| `        ├── consumer-group`                  | `String`          | none                                                                                                                    |
+| `        ├── autostart-enabled`               | `boolean`         | `true`                                                                                                                  |
+| `        ├── record-metrics`                  | `boolean`         | `false`                                                                                                                 |
+| `        ├── read-From`                       | `Position`        | `end` (`begin`)                                                                                                         |
+| `        ├── oauth`                           |                   |                                                                                                                         |
+| `        │   ├── enabled`                     | `boolean`         | `false`                                                                                                                 |
+| `        │   └── access-token-id`             | `String`          | none                                                                                                                    |
+| `        ├── http`                            |                   |                                                                                                                         |
+| `        │   ├── socket-timeout`              | `TimeSpan`        | `5 seconds`                                                                                                             |
+| `        │   ├── connect-timeout`             | `TimeSpan`        | `5 seconds`                                                                                                             |
+| `        │   ├── connection-request-timeout`  | `TimeSpan`        | `5 seconds`                                                                                                             |
+| `        │   ├── content-encoding`            | `ContentEncoding` | `gzip` (`identity`)                                                                                                     |
+| `        │   ├── content-compression-enabled` | `boolean`         | `false`                                                                                                                 |
+| `        │   ├── buffer-size`                 | `int`             | `512`                                                                                                                   |
+| `        │   ├── connection-time-to-live`     | `TimeSpan`        | `30 seconds`                                                                                                            |
+| `        │   ├── max-connections-total`       | `int`             | `3`                                                                                                                     |
+| `        │   ├── max-connections-per-route`   | `int`             | `3`                                                                                                                     |
+| `        │   ├── evict-expired-connections`   | `boolean`         | `true`                                                                                                                  |
+| `        │   ├── evict-idle-connections`      | `boolean`         | `true`                                                                                                                  |
+| `        │   └── max-idle-time`               | `int`             | `10_000`                                                                                                                |
+| `        ├── backoff`                         |                   |                                                                                                                         |
+| `        │   ├── enabled`                     | `boolean`         | `false`                                                                                                                 |
+| `        │   ├── intial-delay`                | `TimeSpan`        | `500 milliseconds`                                                                                                      |
+| `        │   ├── max-delay`                   | `TimeSpan`        | `10 minutes`                                                                                                            |
+| `        │   ├── backoff-factor`              | `double`          | `1.5`                                                                                                                   |
+| `        │   ├── max-retries`                 | `int`             | `1`                                                                                                                     |
+| `        │   └── jitter`                      |                   |                                                                                                                         |
+| `        │       ├── enabled`                 | `boolean`         | `false`                                                                                                                 |
+| `        │       └── type`                    | `JitterType`      | `equal` (`full`)                                                                                                        |
+| `        ├── threads`                         |                   |                                                                                                                         |
+| `        │   └── listener-pool-size`          | `int`             | `1`                                                                                                                     |
+| `        ├── oauth`                           |                   |                                                                                                                         |
+| `        │   ├── enabled`                     | `boolean`         | `false`                                                                                                                 |
+| `        │   └── access-token-id`             | `String`          | none                                                                                                                    |
+| `        └── stream-parameters`               |                   |
+| `            ├── batch-limit`                 | `int`             | [default value](https://nakadi.io/manual.html#/subscriptions/subscription_id/events_get*batch_limit)                    |                                                                    
+| `            ├── stream-limit`                | `int`             | [default value](https://nakadi.io/manual.html#/subscriptions/subscription_id/events_get*stream_limit)                   |                                                                      
+| `            ├── batch-flush-timeout`         | `TimeSpan`        | [default value](https://nakadi.io/manual.html#/subscriptions/subscription_id/events_get*batch_flush_timeout)            |
+| `            ├── stream-timeout`              | `TimeSpan`        | [default value](https://nakadi.io/manual.html#/subscriptions/subscription_id/events_get*stream_timeout)                 |
+| `            ├── commit-timeout`              | `TimeSpan`        | [default value](https://nakadi.io/manual.html#/subscriptions/subscription_id/events_get*commit_timeout)                 |
+| `            ├── stream-keep-alive-limit`     | `int`             | [default value](https://nakadi.io/manual.html#/subscriptions/subscription_id/events_get*stream_keep_alive_limit)        |
+| `            ├── batch-timespan`              | `TimeSpan`        | none                                                                                                                    |
+| `            └── max-uncommitted-events`      | `int`             | [default value](https://nakadi.io/manual.html#/subscriptions/subscription_id/events_get*max_uncommitted_events)         |

--- a/fahrschein-spring-boot-starter/src/main/java/org/zalando/spring/boot/fahrschein/config/TimeSpan.java
+++ b/fahrschein-spring-boot-starter/src/main/java/org/zalando/spring/boot/fahrschein/config/TimeSpan.java
@@ -3,6 +3,7 @@ package org.zalando.spring.boot.fahrschein.config;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.Arrays;
 import java.util.Locale;
@@ -19,6 +20,7 @@ import static org.zalando.fahrschein.Preconditions.checkArgument;
 @AllArgsConstructor(staticName = "of")
 @Getter
 @EqualsAndHashCode
+@Slf4j
 public final class TimeSpan {
 
     private static final Pattern PATTERN = Pattern.compile("(\\d+) (\\w+)");
@@ -33,6 +35,9 @@ public final class TimeSpan {
     public TimeSpan(final String value) {
         this(TimeSpan.valueOf(value));
     }
+
+    // used by SnakeYAML
+    public TimeSpan(final Integer value) { this(TimeSpan.valueOf(value)); }
 
     private TimeSpan(final TimeSpan span) {
         this(span.amount, span.unit);
@@ -49,6 +54,11 @@ public final class TimeSpan {
     @Override
     public String toString() {
         return amount + " " + toName(unit);
+    }
+
+    static TimeSpan valueOf(final int value) {
+       log.warn("TimeSpan without unit found. Assuming seconds.", value);
+       return new TimeSpan(value, TimeUnit.SECONDS);
     }
 
     static TimeSpan valueOf(final String value) {

--- a/fahrschein-spring-boot-starter/src/main/java/org/zalando/spring/boot/fahrschein/config/TimeSpan.java
+++ b/fahrschein-spring-boot-starter/src/main/java/org/zalando/spring/boot/fahrschein/config/TimeSpan.java
@@ -8,6 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import java.util.Arrays;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.regex.Matcher;
@@ -19,7 +20,6 @@ import static org.zalando.fahrschein.Preconditions.checkArgument;
 
 @AllArgsConstructor(staticName = "of")
 @Getter
-@EqualsAndHashCode
 @Slf4j
 public final class TimeSpan {
 
@@ -43,7 +43,7 @@ public final class TimeSpan {
         this(span.amount, span.unit);
     }
 
-    long to(final TimeUnit targetUnit) {
+    public long to(final TimeUnit targetUnit) {
         return targetUnit.convert(amount, unit);
     }
 
@@ -89,4 +89,16 @@ public final class TimeSpan {
         return unit.name().toLowerCase(Locale.ROOT);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TimeSpan timeSpan = (TimeSpan) o;
+        return to(TimeUnit.MILLISECONDS) == timeSpan.to(TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(to(TimeUnit.MILLISECONDS));
+    }
 }

--- a/fahrschein-spring-boot-starter/src/main/java/org/zalando/spring/boot/fahrschein/nakadi/config/FahrscheinNakadiConsumer.java
+++ b/fahrschein-spring-boot-starter/src/main/java/org/zalando/spring/boot/fahrschein/nakadi/config/FahrscheinNakadiConsumer.java
@@ -17,6 +17,7 @@ import org.zalando.fahrschein.SubscriptionBuilder;
 import org.zalando.fahrschein.domain.Authorization.AuthorizationAttribute;
 import org.zalando.fahrschein.domain.Subscription;
 import org.zalando.fahrschein.metrics.micrometer.MicrometerMetricsCollector;
+import org.zalando.spring.boot.fahrschein.config.TimeSpan;
 import org.zalando.spring.boot.fahrschein.nakadi.MeterRegistryAware;
 import org.zalando.spring.boot.fahrschein.nakadi.NakadiListener;
 import org.zalando.spring.boot.fahrschein.nakadi.config.properties.BackoffConfig;
@@ -28,6 +29,7 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static org.zalando.fahrschein.AuthorizationBuilder.authorization;
 import static org.zalando.spring.boot.fahrschein.nakadi.config.properties.Position.END;
@@ -152,7 +154,7 @@ public class FahrscheinNakadiConsumer implements NakadiConsumer, MeterRegistryAw
 
             StreamParameters sp = new StreamParameters();
             if (config.getBatchFlushTimeout() != null) {
-                sp = sp.withBatchFlushTimeout((int) config.getBatchFlushTimeout());
+                sp = sp.withBatchFlushTimeout(timeUnitToSeconds(config.getBatchFlushTimeout()));
             }
 
             if (config.getBatchLimit() != null) {
@@ -164,17 +166,30 @@ public class FahrscheinNakadiConsumer implements NakadiConsumer, MeterRegistryAw
             }
 
             if (config.getStreamKeepAliveLimit() != null) {
-                sp = sp.withStreamKeepAliveLimit((int) config.getStreamKeepAliveLimit());
+                sp = sp.withStreamKeepAliveLimit(timeUnitToSeconds(config.getStreamKeepAliveLimit()));
             }
 
             if (config.getStreamLimit() != null) {
                 sp = sp.withStreamLimit((int) config.getStreamLimit());
             }
+
             if (config.getStreamTimeout() != null) {
-                sp = sp.withStreamTimeout((int) config.getStreamTimeout());
+                sp = sp.withStreamTimeout(timeUnitToSeconds(config.getStreamTimeout()));
+            }
+
+            if (config.getCommitTimeout() != null) {
+                sp = sp.withCommitTimeout(timeUnitToSeconds(config.getCommitTimeout()));
+            }
+
+            if (config.getBatchTimespan() != null) {
+                sp = sp.withBatchTimespan(timeUnitToSeconds(config.getBatchTimespan()));
             }
             return sp;
         }
+    }
+
+    private static int timeUnitToSeconds(TimeSpan t) {
+        return (int) t.getUnit().toSeconds(t.getAmount());
     }
 
 }

--- a/fahrschein-spring-boot-starter/src/main/java/org/zalando/spring/boot/fahrschein/nakadi/config/FahrscheinNakadiConsumer.java
+++ b/fahrschein-spring-boot-starter/src/main/java/org/zalando/spring/boot/fahrschein/nakadi/config/FahrscheinNakadiConsumer.java
@@ -17,7 +17,6 @@ import org.zalando.fahrschein.SubscriptionBuilder;
 import org.zalando.fahrschein.domain.Authorization.AuthorizationAttribute;
 import org.zalando.fahrschein.domain.Subscription;
 import org.zalando.fahrschein.metrics.micrometer.MicrometerMetricsCollector;
-import org.zalando.spring.boot.fahrschein.config.TimeSpan;
 import org.zalando.spring.boot.fahrschein.nakadi.MeterRegistryAware;
 import org.zalando.spring.boot.fahrschein.nakadi.NakadiListener;
 import org.zalando.spring.boot.fahrschein.nakadi.config.properties.BackoffConfig;
@@ -29,7 +28,6 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.zalando.fahrschein.AuthorizationBuilder.authorization;

--- a/fahrschein-spring-boot-starter/src/main/java/org/zalando/spring/boot/fahrschein/nakadi/config/FahrscheinNakadiConsumer.java
+++ b/fahrschein-spring-boot-starter/src/main/java/org/zalando/spring/boot/fahrschein/nakadi/config/FahrscheinNakadiConsumer.java
@@ -31,6 +31,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.zalando.fahrschein.AuthorizationBuilder.authorization;
 import static org.zalando.spring.boot.fahrschein.nakadi.config.properties.Position.END;
 
@@ -154,7 +155,7 @@ public class FahrscheinNakadiConsumer implements NakadiConsumer, MeterRegistryAw
 
             StreamParameters sp = new StreamParameters();
             if (config.getBatchFlushTimeout() != null) {
-                sp = sp.withBatchFlushTimeout(timeUnitToSeconds(config.getBatchFlushTimeout()));
+                sp = sp.withBatchFlushTimeout((int) config.getBatchFlushTimeout().to(SECONDS));
             }
 
             if (config.getBatchLimit() != null) {
@@ -166,7 +167,7 @@ public class FahrscheinNakadiConsumer implements NakadiConsumer, MeterRegistryAw
             }
 
             if (config.getStreamKeepAliveLimit() != null) {
-                sp = sp.withStreamKeepAliveLimit(timeUnitToSeconds(config.getStreamKeepAliveLimit()));
+                sp = sp.withStreamKeepAliveLimit(config.getStreamKeepAliveLimit());
             }
 
             if (config.getStreamLimit() != null) {
@@ -174,22 +175,17 @@ public class FahrscheinNakadiConsumer implements NakadiConsumer, MeterRegistryAw
             }
 
             if (config.getStreamTimeout() != null) {
-                sp = sp.withStreamTimeout(timeUnitToSeconds(config.getStreamTimeout()));
+                sp = sp.withStreamTimeout((int)config.getStreamTimeout().to(SECONDS));
             }
 
             if (config.getCommitTimeout() != null) {
-                sp = sp.withCommitTimeout(timeUnitToSeconds(config.getCommitTimeout()));
+                sp = sp.withCommitTimeout((int) config.getCommitTimeout().to(SECONDS));
             }
 
             if (config.getBatchTimespan() != null) {
-                sp = sp.withBatchTimespan(timeUnitToSeconds(config.getBatchTimespan()));
+                sp = sp.withBatchTimespan((int) config.getBatchTimespan().to(SECONDS));
             }
             return sp;
         }
     }
-
-    private static int timeUnitToSeconds(TimeSpan t) {
-        return (int) t.getUnit().toSeconds(t.getAmount());
-    }
-
 }

--- a/fahrschein-spring-boot-starter/src/main/java/org/zalando/spring/boot/fahrschein/nakadi/config/properties/StreamParametersConfig.java
+++ b/fahrschein-spring-boot-starter/src/main/java/org/zalando/spring/boot/fahrschein/nakadi/config/properties/StreamParametersConfig.java
@@ -11,7 +11,7 @@ public class StreamParametersConfig {
     private Integer streamLimit;
     private TimeSpan batchFlushTimeout;
     private TimeSpan streamTimeout;
-    private TimeSpan streamKeepAliveLimit;
+    private Integer streamKeepAliveLimit;
     private TimeSpan commitTimeout;
     private TimeSpan batchTimespan;
 

--- a/fahrschein-spring-boot-starter/src/main/java/org/zalando/spring/boot/fahrschein/nakadi/config/properties/StreamParametersConfig.java
+++ b/fahrschein-spring-boot-starter/src/main/java/org/zalando/spring/boot/fahrschein/nakadi/config/properties/StreamParametersConfig.java
@@ -1,6 +1,7 @@
 package org.zalando.spring.boot.fahrschein.nakadi.config.properties;
 
 import lombok.Data;
+import org.zalando.spring.boot.fahrschein.config.TimeSpan;
 
 import java.util.Optional;
 
@@ -8,9 +9,11 @@ import java.util.Optional;
 public class StreamParametersConfig {
     private Integer batchLimit;
     private Integer streamLimit;
-    private Integer batchFlushTimeout;
-    private Integer streamTimeout;
-    private Integer streamKeepAliveLimit;
+    private TimeSpan batchFlushTimeout;
+    private TimeSpan streamTimeout;
+    private TimeSpan streamKeepAliveLimit;
+    private TimeSpan commitTimeout;
+    private TimeSpan batchTimespan;
 
     // Only used in the subscription api
     private Integer maxUncommittedEvents;
@@ -21,6 +24,8 @@ public class StreamParametersConfig {
         this.setBatchFlushTimeout(Optional.ofNullable(this.getBatchFlushTimeout()).orElse(defaultStreamParametersConfig.getBatchFlushTimeout()));
         this.setStreamTimeout(Optional.ofNullable(this.getStreamTimeout()).orElse(defaultStreamParametersConfig.getStreamTimeout()));
         this.setStreamKeepAliveLimit(Optional.ofNullable(this.getStreamKeepAliveLimit()).orElse(defaultStreamParametersConfig.getStreamKeepAliveLimit()));
+        this.setCommitTimeout(Optional.ofNullable(this.getCommitTimeout()).orElse(defaultStreamParametersConfig.getCommitTimeout()));
+        this.setBatchTimespan(Optional.ofNullable(this.getBatchTimespan()).orElse(defaultStreamParametersConfig.getBatchTimespan()));
         this.setMaxUncommittedEvents(Optional.ofNullable(this.getMaxUncommittedEvents()).orElse(defaultStreamParametersConfig.getMaxUncommittedEvents()));
     }
 

--- a/fahrschein-spring-boot-starter/src/test/java/org/zalando/spring/boot/fahrschein/nakadi/ApplicationTest.java
+++ b/fahrschein-spring-boot-starter/src/test/java/org/zalando/spring/boot/fahrschein/nakadi/ApplicationTest.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -108,8 +109,8 @@ public class ApplicationTest {
         assertThat(dc.getStreamParameters())
                 .hasFieldOrPropertyWithValue("batchLimit", 1)
                 .hasFieldOrPropertyWithValue("streamLimit", 1)
-                .hasFieldOrPropertyWithValue("batchFlushTimeout", 2)
-                .hasFieldOrPropertyWithValue("streamTimeout", 2)
+                .hasFieldOrPropertyWithValue("batchFlushTimeout", TimeSpan.of(2, SECONDS))
+                .hasFieldOrPropertyWithValue("streamTimeout", TimeSpan.of(2, SECONDS))
                 .hasFieldOrPropertyWithValue("maxUncommittedEvents", 2)
                 .hasNoNullFieldsOrProperties();
 

--- a/fahrschein-spring-boot-starter/src/test/java/org/zalando/spring/boot/fahrschein/nakadi/ApplicationTest.java
+++ b/fahrschein-spring-boot-starter/src/test/java/org/zalando/spring/boot/fahrschein/nakadi/ApplicationTest.java
@@ -111,6 +111,8 @@ public class ApplicationTest {
                 .hasFieldOrPropertyWithValue("streamLimit", 1)
                 .hasFieldOrPropertyWithValue("batchFlushTimeout", TimeSpan.of(2, SECONDS))
                 .hasFieldOrPropertyWithValue("streamTimeout", TimeSpan.of(2, SECONDS))
+                .hasFieldOrPropertyWithValue("commitTimeout", TimeSpan.of(60, SECONDS))
+                .hasFieldOrPropertyWithValue("streamKeepAliveLimit", 5)
                 .hasFieldOrPropertyWithValue("maxUncommittedEvents", 2)
                 .hasNoNullFieldsOrProperties();
 

--- a/fahrschein-spring-boot-starter/src/test/java/org/zalando/spring/boot/fahrschein/nakadi/ApplicationTest.java
+++ b/fahrschein-spring-boot-starter/src/test/java/org/zalando/spring/boot/fahrschein/nakadi/ApplicationTest.java
@@ -26,7 +26,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 

--- a/fahrschein-spring-boot-starter/src/test/java/org/zalando/spring/boot/fahrschein/nakadi/config/TimeSpanTest.java
+++ b/fahrschein-spring-boot-starter/src/test/java/org/zalando/spring/boot/fahrschein/nakadi/config/TimeSpanTest.java
@@ -1,0 +1,40 @@
+package org.zalando.spring.boot.fahrschein.nakadi.config;
+
+import org.junit.jupiter.api.Test;
+import org.zalando.spring.boot.fahrschein.config.TimeSpan;
+
+import static java.util.concurrent.TimeUnit.*;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.assertj.core.api.Assertions.*;
+
+public class TimeSpanTest {
+
+    @Test
+    public void testEqualsHashCode() {
+        assertThat(TimeSpan.of(10, MINUTES)).isEqualTo(TimeSpan.of(600, SECONDS));
+        assertThat(TimeSpan.of(10, MINUTES)).isNotEqualTo(TimeSpan.of(601, SECONDS));
+        assertThat(TimeSpan.of(10, MINUTES).hashCode()).isEqualTo(TimeSpan.of(600, SECONDS).hashCode());
+    }
+
+    @Test
+    public void testConversion() {
+        assertThat(TimeSpan.of(10, MINUTES).to(SECONDS)).isEqualTo(600);
+    }
+
+    @Test
+    public void testToString() {
+        assertThat(TimeSpan.of(10, MINUTES).toString()).isEqualTo("10 minutes");
+    }
+
+    @Test
+    public void testParsing() {
+        assertThat(new TimeSpan("5 minutes")).isEqualTo(TimeSpan.of(5, MINUTES));
+        assertThat(new TimeSpan("")).isEqualTo(TimeSpan.of(0, MINUTES));
+    }
+
+    @Test
+    public void testSecondsFallback() {
+        assertThat(new TimeSpan(60)).isEqualTo(TimeSpan.of(60, SECONDS));
+    }
+
+}

--- a/fahrschein-spring-boot-starter/src/test/java/org/zalando/spring/boot/fahrschein/nakadi/config/properties/ConsumerConfigTest.java
+++ b/fahrschein-spring-boot-starter/src/test/java/org/zalando/spring/boot/fahrschein/nakadi/config/properties/ConsumerConfigTest.java
@@ -13,7 +13,7 @@ public class ConsumerConfigTest {
 
     private static final TimeSpan STREAM_TIMEOUT = TimeSpan.of(5, TimeUnit.SECONDS);
     private static final int STREAM_LIMIT = 23;
-    private static final TimeSpan STREAM_KEEP_ALIVE_LIMIT = TimeSpan.of(34, TimeUnit.SECONDS);
+    private static final int STREAM_KEEP_ALIVE_LIMIT = 34;
     private static final int MAX_UNCOMMITTED_EVENTS = 9000;
     private static final int BATCH_LIMIT = 1000;
     private static final TimeSpan BATCH_FLUSH_TIMEOUT = TimeSpan.of(12, TimeUnit.SECONDS);

--- a/fahrschein-spring-boot-starter/src/test/java/org/zalando/spring/boot/fahrschein/nakadi/config/properties/ConsumerConfigTest.java
+++ b/fahrschein-spring-boot-starter/src/test/java/org/zalando/spring/boot/fahrschein/nakadi/config/properties/ConsumerConfigTest.java
@@ -2,19 +2,21 @@ package org.zalando.spring.boot.fahrschein.nakadi.config.properties;
 
 import org.junit.jupiter.api.Test;
 import org.zalando.fahrschein.http.api.ContentEncoding;
+import org.zalando.spring.boot.fahrschein.config.TimeSpan;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ConsumerConfigTest {
 
-    private static final int STREAM_TIMEOUT = 5;
+    private static final TimeSpan STREAM_TIMEOUT = TimeSpan.of(5, TimeUnit.SECONDS);
     private static final int STREAM_LIMIT = 23;
-    private static final int STREAM_KEEP_ALIVE_LIMIT = 34;
+    private static final TimeSpan STREAM_KEEP_ALIVE_LIMIT = TimeSpan.of(34, TimeUnit.SECONDS);
     private static final int MAX_UNCOMMITTED_EVENTS = 9000;
     private static final int BATCH_LIMIT = 1000;
-    private static final int BATCH_FLUSH_TIMEOUT = 12;
+    private static final TimeSpan BATCH_FLUSH_TIMEOUT = TimeSpan.of(12, TimeUnit.SECONDS);
     private static final String USER_4 = "user_4";
     private static final String USER_5 = "user_5";
     private static final String TEST_TEAM = "team";

--- a/fahrschein-spring-boot-starter/src/test/resources/application.yml
+++ b/fahrschein-spring-boot-starter/src/test/resources/application.yml
@@ -33,6 +33,8 @@ fahrschein:
       streamTimeout: 2
       streamKeepAliveLimit: 2
       maxUncommittedEvents: 2
+      commit-timeout: 30 seconds
+      batch-timespan: 10 seconds
     oauth:
       enabled: false
       access-token-id: token_id #same token_id used for all consumers

--- a/fahrschein-spring-boot-starter/src/test/resources/application.yml
+++ b/fahrschein-spring-boot-starter/src/test/resources/application.yml
@@ -31,9 +31,9 @@ fahrschein:
       streamLimit: 1
       batchFlushTimeout: 2
       streamTimeout: 2
-      streamKeepAliveLimit: 2
+      streamKeepAliveLimit: 5
       maxUncommittedEvents: 2
-      commit-timeout: 30 seconds
+      commit-timeout: 1 minute
       batch-timespan: 10 seconds
     oauth:
       enabled: false


### PR DESCRIPTION
Closes #429 

## Changes

- makes time-based stream parameters batchFlushTimeout, streamTimeout, commitTimeout and batchTimespan of type timespan in the yaml configuration
- allows fallback to int-values, assuming "seconds" as unit (but emitting a [warning in the logs](https://github.com/zalando-nakadi/fahrschein/pull/433/files#diff-dfc37828957b018ab4ffca16b96db55e9b9bea7c277738346686dfcb391a49a6R60))
