### PR TITLE
Remove deprecated Jackson 2.7 property CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,4 +31,4 @@ jobs:
       - name: Test oldest supported library versions
         run: gradle build -Pjackson.version=2.8.0 -Pspring.version=6.0.0 -Pspringboot.version=3.0.0 -Pokhttp.version=3.3.0 -Papachehttp.version=4.4
       - name: Test with latest library (minor) updates
-        run: gradle build -Pjackson.version=2.+ -Pspring.version=6.+ -Pspringboot.version=3.+ -Pokhttp.version=4.+ -Papachehttp.version=4.+ -Pjdk.version=17
+        run: gradle build -Pjackson.version=2.+ -Pspring.version=6.+ -Pspringboot.version=3.+ -Pokhttp.version=4.+ -Papachehttp.version=4.+ -Pjdk.version=21

--- a/README.md
+++ b/README.md
@@ -370,12 +370,12 @@ public void readSalesOrderPlacedEvents() throws IOException {
 Although Fahrschein is using fixed dependency versions, it is integration-tested against the following dependency matrix. We will inform in the release notes in case we bump the compatibility baseline. 
 
 | Dependency        | Baseline | Latest |
-| ----------------- |----------| ------ |
+|-------------------|----------|--------|
 | Jackson           | 2.8.0    | 2.+    |
 | Spring Core       | 6.0.0    | 6.+    |
 | Spring Boot       | 3.0.0    | 3.+    |
 | okHttp            | 3.3.0    | 4.+    |
-| Apache HttpClient | 4.4      | 4.+    |
+| Apache HttpClient | 4.4      | 4.+    |
 
 ## Content-Compression
 

--- a/fahrschein-e2e-test/src/test/java/org/zalando/fahrschein/e2e/NakadiClientEnd2EndTest.java
+++ b/fahrschein-e2e-test/src/test/java/org/zalando/fahrschein/e2e/NakadiClientEnd2EndTest.java
@@ -4,6 +4,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
@@ -78,7 +79,7 @@ public class NakadiClientEnd2EndTest extends NakadiTestWithDockerCompose {
     static {
         objectMapper.registerModule(new JavaTimeModule());
         objectMapper.registerModule(new Jdk8Module());
-        objectMapper.setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES);
+        objectMapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
         objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         // After a Nakadi-Docker upgrade, check if the response metadata changed
         // by enabling deserialization failure on unknown properties.

--- a/fahrschein-typeresolver/src/test/java/org/zalando/fahrschein/typeresolver/MetadataTypeResolverTest.java
+++ b/fahrschein-typeresolver/src/test/java/org/zalando/fahrschein/typeresolver/MetadataTypeResolverTest.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonTypeResolver;
 import org.junit.jupiter.api.Test;
@@ -90,7 +91,7 @@ public class MetadataTypeResolverTest {
     private final ObjectMapper objectMapper = new ObjectMapper();
     {
         objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
-        objectMapper.setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES);
+        objectMapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
         objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
     }
 

--- a/fahrschein/src/main/java/org/zalando/fahrschein/DefaultObjectMapper.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/DefaultObjectMapper.java
@@ -3,6 +3,7 @@ package org.zalando.fahrschein;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
@@ -21,10 +22,9 @@ class DefaultObjectMapper {
         INSTANCE = objectMapper;
     }
 
-    @SuppressWarnings("deprecation")
     private static PropertyNamingStrategy snake_case() {
-        // Use the deprecated constant instead of SNAKE_CASE to remain compatible with jackson versions < 2.7
-        return PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES;
+        // Use the constant SNAKE_CASE, dropping compatibility with jackson versions < 2.7
+        return PropertyNamingStrategies.SNAKE_CASE;
     }
 
     private DefaultObjectMapper() {

--- a/fahrschein/src/main/java/org/zalando/fahrschein/NakadiClientBuilder.java
+++ b/fahrschein/src/main/java/org/zalando/fahrschein/NakadiClientBuilder.java
@@ -88,7 +88,7 @@ public final class NakadiClientBuilder {
     /**
      * Creates a new instance of {@code NakadiClient}. In case no {@code ObjectMapper} is provided, it's going to make
      * use of {@code DefaultObjectMapper} that is making use of
-     * {@code PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES}.
+     * {@code PropertyNamingStrategies.SNAKE_CASE}.
      * In case no {@code CursorManager} is provided it's going to make use of {@code ManagedCursorManager}.
      *
      * @return A fresh instance of {@code NakadiClient}


### PR DESCRIPTION
The next version of Jackson is going to remove this property, which will make Fahrschein fail (see current ci-latest build workflows)

## References

- https://github.com/FasterXML/jackson-databind/commit/d7a1efc7f45af4f56c0df4eccb0244418b6428bb
- https://github.com/zalando-nakadi/fahrschein/actions/runs/6639117822/job/18036824456
