### PR TITLE
Spring-boot request factory: don't use streaming but buffering implementation

### DIFF
--- a/fahrschein-spring-boot-starter/src/main/java/org/zalando/spring/boot/fahrschein/nakadi/config/RequestFactories.java
+++ b/fahrschein-spring-boot-starter/src/main/java/org/zalando/spring/boot/fahrschein/nakadi/config/RequestFactories.java
@@ -37,7 +37,7 @@ public class RequestFactories {
     private static ClientHttpRequestFactorySettings httpConfigToClientHttpRequestFactorySettings(HttpConfig httpConfig) {
         return new ClientHttpRequestFactorySettings(
                 Duration.ofMillis((int) MILLISECONDS.convert(httpConfig.getConnectTimeout().getAmount(), httpConfig.getConnectTimeout().getUnit())),
-                Duration.ofMillis((int) MILLISECONDS.convert(httpConfig.getSocketTimeout().getAmount(), httpConfig.getSocketTimeout().getUnit())), false);
+                Duration.ofMillis((int) MILLISECONDS.convert(httpConfig.getSocketTimeout().getAmount(), httpConfig.getSocketTimeout().getUnit())), true);
     }
 
 }


### PR DESCRIPTION
Fixes  #435

## Reproducing the issue

The `ClientHttpRequestFactories` from Spring defaults to using Apache HttpClient 5.x (which we haven't tested our stack against) if it exists on the classpath. This HTTP client has two implementations, a streaming and a buffering one. We picked the wrong one - we need to pick buffering, not streaming, because we are calling getBody() to access the full content of the response body.

## Fix

There is a backwards-compatible implementation which gets picked when you set `buffering=true`.

