### PR TITLE
Spring Boot: Add Subscription config properties when subscription-by-id is not provided

### DIFF
--- a/fahrschein-spring-boot-starter/src/main/java/org/zalando/spring/boot/fahrschein/nakadi/config/FahrscheinNakadiConsumer.java
+++ b/fahrschein-spring-boot-starter/src/main/java/org/zalando/spring/boot/fahrschein/nakadi/config/FahrscheinNakadiConsumer.java
@@ -141,7 +141,7 @@ public class FahrscheinNakadiConsumer implements NakadiConsumer, MeterRegistryAw
         if (consumerConfig.getSubscriptionById() != null && !consumerConfig.getSubscriptionById().isEmpty()) {
             return sb.subscribe(consumerConfig.getSubscriptionById());
         } else {
-            sb
+            sb = sb
                 .withConsumerGroup(consumerConfig.getConsumerGroup())
                 .withAuthorization(authorization()
                         .withAdmins(adminAttributes)


### PR DESCRIPTION
Spring Boot: FahrscheinNakadiConsumer ignores consumer properties when subscription-id is not provided https://github.com/zalando-nakadi/fahrschein/issues/450

Contributed by @levabski

Supersedes  #451 (needed to rebase PR)
