### PR TITLE
Fix Fahrschein using invalid OAuth configs when committing cursors

### DIFF
--- a/fahrschein-spring-boot-starter/src/main/java/org/zalando/spring/boot/fahrschein/nakadi/config/CursorManagerFactory.java
+++ b/fahrschein-spring-boot-starter/src/main/java/org/zalando/spring/boot/fahrschein/nakadi/config/CursorManagerFactory.java
@@ -4,13 +4,19 @@ import org.zalando.fahrschein.CursorManager;
 import org.zalando.fahrschein.ManagedCursorManager;
 import org.zalando.fahrschein.http.api.RequestFactory;
 import org.zalando.spring.boot.fahrschein.nakadi.config.properties.AbstractConfig;
+import org.zalando.spring.boot.fahrschein.nakadi.config.properties.OAuthConfig;
 
 import java.net.URI;
 
 class CursorManagerFactory {
 
     static CursorManager create(AbstractConfig config, RequestFactory requestFactory) {
-        return new ManagedCursorManager(URI.create(config.getNakadiUrl()), requestFactory,
-                OAuth.buildAccessTokenProvider(config.getOauth()));
+        OAuthConfig oauth = config.getOauth();
+        if (oauth.getEnabled()) {
+            return new ManagedCursorManager(URI.create(config.getNakadiUrl()), requestFactory,
+                    OAuth.buildAccessTokenProvider(oauth));
+        }
+
+        return new ManagedCursorManager(URI.create(config.getNakadiUrl()), requestFactory);
     }
 }


### PR DESCRIPTION
Fahrschein tries to add authorisation to requests when committing cursors even if OAuth is disabled.

This leads to errors such as:
```
java.nio.file.NoSuchFileException: /meta/credentials/nakadi-token-secret
        at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92) ~[na:na]
        at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106) ~[na:na]
        at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111) ~[na:na]
        at java.base/sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:261) ~[na:na]
        at java.base/java.nio.file.Files.newByteChannel(Files.java:379) ~[na:na]
        at java.base/java.nio.file.Files.newByteChannel(Files.java:431) ~[na:na]
        at java.base/java.nio.file.Files.readAllBytes(Files.java:3268) ~[na:na]
        at org.zalando.fahrschein.PlatformAccessTokenProvider.getAccessToken(PlatformAccessTokenProvider.java:52) ~[fahrschein-2.0.0.jar:na]
        at org.zalando.fahrschein.AccessTokenProvider.getAuthorizationHeader(AccessTokenProvider.java:10) ~[fahrschein-2.0.0.jar:na]
        at org.zalando.fahrschein.AuthorizedRequestFactory.createRequest(AuthorizedRequestFactory.java:21) ~[fahrschein-2.0.0.jar:na]
        at org.zalando.fahrschein.ManagedCursorManager.onSuccess(ManagedCursorManager.java:120) ~[fahrschein-2.0.0.jar:na]
        at org.zalando.fahrschein.NakadiReader$2.run(NakadiReader.java:209) ~[fahrschein-2.0.0.jar:na]
        at org.zalando.fahrschein.DefaultBatchHandler.processBatch(DefaultBatchHandler.java:13) ~[fahrschein-2.0.0.jar:na]
        at org.zalando.fahrschein.NakadiReader.processBatch(NakadiReader.java:204) ~[fahrschein-2.0.0.jar:na]
        at org.zalando.fahrschein.NakadiReader.readBatch(NakadiReader.java:425) ~[fahrschein-2.0.0.jar:na]
        at org.zalando.fahrschein.NakadiReader.runInternal(NakadiReader.java:291) ~[fahrschein-2.0.0.jar:na]
        at org.zalando.fahrschein.NakadiReader.run(NakadiReader.java:265) ~[fahrschein-2.0.0.jar:na]
        at org.zalando.fahrschein.IORunnable.lambda$unchecked$0(IORunnable.java:13) ~[fahrschein-2.0.0.jar:na]
        at org.springframework.scheduling.support.DelegatingErrorHandlingRunnable.run(DelegatingErrorHandlingRunnable.java:54) ~[spring-context-6.1.2.jar:6.1.2]
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572) ~[na:na]
        at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:358) ~[na:na]
        at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305) ~[na:na]
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[na:na]
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[na:na]
        at java.base/java.lang.Thread.run(Thread.java:1583) ~[na:na]
```

So even though we're able to listen to the event, which is done auth-free, when committing the cursor Fahrschein tries to read the OAuth configs without first checking if they're enabled.

To repro it, simply run a local Nakadi (with no auth settings, obviously) and add this to your spring-boot application:
```kotlin
@NakadiEventListener("FooBar")
class Listener : NakadiListener<Event> {
  override fun accept(events: MutableList<Event>) {
    events.forEach { event -> println(event) }
  }

  override fun getEventType() = Event::class.java
}
```

The application runs normally and the subscription is created and the app listens for events. Once one is received, the aforementioned error is thrown.