### PR TITLE
Skip codacy check from forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,12 @@ jobs:
       - name: codacy
         env:
           CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
-        run: bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r ./build/reports/jacoco/jacocoAggregateReport/jacocoAggregateReport.xml
+        run: |
+          if [[ ! -z "${CODACY_PROJECT_TOKEN}" ]]; then
+            bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r ./build/reports/jacoco/jacocoAggregateReport/jacocoAggregateReport.xml
+          else
+            echo "Skipping codacy due to security restrictions for PRs from forks."
+          fi
       - uses: codecov/codecov-action@v3
         with:
           files: ./build/reports/jacoco/jacocoAggregateReport/jacocoAggregateReport.xml


### PR DESCRIPTION
There are security constraints so that we cannot use a secret in github actions from forks. This makes the codacy step fail.

## Change

- Makes the execution of codacy conditional to only PRs from non-forks.

## Alternatives considered

- Allowing exposure of secrets to PRs from forks can only be org-centrally enabled. If we had this enabled, and manual approval of running Github workflows for forks, we would be good. But it's unlikely to happen due to risks of exposing sensitive secrets.
